### PR TITLE
Proper location of properties

### DIFF
--- a/samples/react-organisationchart/src/webparts/organisationChart/IOrganisationChartWebPartProps.ts
+++ b/samples/react-organisationchart/src/webparts/organisationChart/IOrganisationChartWebPartProps.ts
@@ -2,6 +2,4 @@ import { ServiceScope, EnvironmentType } from '@microsoft/sp-client-base';
 
 export interface IOrganisationChartWebPartProps {
   description: string;
-  environmentType: EnvironmentType;
-  serviceScope: ServiceScope;
 }

--- a/samples/react-organisationchart/src/webparts/organisationChart/components/OrganisationChart.tsx
+++ b/samples/react-organisationchart/src/webparts/organisationChart/components/OrganisationChart.tsx
@@ -17,6 +17,8 @@ export interface IOrganisationChartWebPartState {
 }
 
 export interface IOrganisationChartProps extends IOrganisationChartWebPartProps {
+  environmentType: EnvironmentType;
+  serviceScope: ServiceScope;
 }
 
 export default class OrganisationChart extends React.Component<IOrganisationChartProps, IOrganisationChartWebPartState> {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | none

#### What's in this Pull Request?

environmentType and serviceScope should not be in the web part properties and persisted, they are only required for the React component