### PR TITLE
Modern page header configurator with color picker property control

### DIFF
--- a/samples/react-pageheaderconfigurator/.editorconfig
+++ b/samples/react-pageheaderconfigurator/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# we recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{package,bower}.json]
+indent_style = space
+indent_size = 2

--- a/samples/react-pageheaderconfigurator/.gitattributes
+++ b/samples/react-pageheaderconfigurator/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/samples/react-pageheaderconfigurator/.gitignore
+++ b/samples/react-pageheaderconfigurator/.gitignore
@@ -1,0 +1,32 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependency directories
+node_modules
+
+# Build generated files
+dist
+lib
+solution
+temp
+*.sppkg
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# OSX
+.DS_Store
+
+# Visual Studio files
+.ntvs_analysis.dat
+.vs
+bin
+obj
+
+# Resx Generated Code
+*.resx.ts
+
+# Styles Generated Code
+*.scss.ts

--- a/samples/react-pageheaderconfigurator/.npmignore
+++ b/samples/react-pageheaderconfigurator/.npmignore
@@ -1,0 +1,14 @@
+# Folders
+.vscode
+coverage
+node_modules
+sharepoint
+src
+temp
+
+# Files
+*.csproj
+.git*
+.yo-rc.json
+gulpfile.js
+tsconfig.json

--- a/samples/react-pageheaderconfigurator/.yo-rc.json
+++ b/samples/react-pageheaderconfigurator/.yo-rc.json
@@ -1,0 +1,8 @@
+{
+  "@microsoft/generator-sharepoint": {
+    "libraryName": "pzl-site-page-header",
+    "framework": "react",
+    "version": "1.0.0",
+    "libraryId": "ed347d47-519f-4f4c-b933-f1a1ec815f56"
+  }
+}

--- a/samples/react-pageheaderconfigurator/README.md
+++ b/samples/react-pageheaderconfigurator/README.md
@@ -1,0 +1,51 @@
+# Modern page header configurator and custom property pane color picker control built in React
+
+## Summary
+A web part to be added to modern site pages to allow configuration of the page banner. The web part allows you to pick the banner size or hide it, override the default background graphics, and change the page headline color.
+
+*Note: This web part injects CSS into the page to override the default CSS provided by a modern page. If the default CSS changes, this web part will no longer work. It is the wish of the author that Microsoft adds this capability as part of a modern page.*
+
+
+![site page header configurator web part](./assets/site-page-header-configurator.gif)
+
+## Used SharePoint Framework Version
+![drop](https://img.shields.io/badge/drop-v1-green.svg)
+
+## Applies to
+
+* [SharePoint Framework Release 1](http://dev.office.com/sharepoint/docs/spfx/sharepoint-framework-overview)
+* Modern site pages in SharePoint Online
+
+## Solution
+
+Solution|Author(s)
+--------|---------
+page header configurator | Mikael Svenson ([@mikaelsvenson](http://www.twitter.com/mikaelsvenson), [techmikael.com](techmikael.com))
+
+## Version history
+
+Version|Date|Comments
+-------|----|--------
+1.0|March 7th, 2017|Initial release
+
+## Disclaimer
+**THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**
+
+---
+
+## Minimal Path to Awesome
+
+- Clone this repository
+- In the command line run:
+  - `npm install`
+  - `gulp clean`
+  - `gulp`
+  - `gulp package-solution`
+  - [Deploy the package to the App catalog and install on a site](https://dev.office.com/sharepoint/docs/spfx/web-parts/get-started/serve-your-web-part-in-a-sharepoint-page)
+
+## Features
+This web part illustrates the following concepts on top of the SharePoint Framework:
+
+- Creating a color picker as a custom property pane control
+- Office UI Fabric
+- React

--- a/samples/react-pageheaderconfigurator/config/config.json
+++ b/samples/react-pageheaderconfigurator/config/config.json
@@ -1,0 +1,13 @@
+{
+  "entries": [
+    {
+      "entry": "./lib/webparts/sitePageHeaderConfigurator/SitePageHeaderConfiguratorWebPart.js",
+      "manifest": "./src/webparts/sitePageHeaderConfigurator/SitePageHeaderConfiguratorWebPart.manifest.json",
+      "outputPath": "./dist/site-page-header-configurator.bundle.js"
+    }
+  ],
+  "externals": {},
+  "localizedResources": {
+    "sitePageHeaderConfiguratorStrings": "webparts/sitePageHeaderConfigurator/loc/{locale}.js"
+  }
+}

--- a/samples/react-pageheaderconfigurator/config/copy-assets.json
+++ b/samples/react-pageheaderconfigurator/config/copy-assets.json
@@ -1,0 +1,3 @@
+{
+  "deployCdnPath": "temp/deploy"
+}

--- a/samples/react-pageheaderconfigurator/config/deploy-azure-storage.json
+++ b/samples/react-pageheaderconfigurator/config/deploy-azure-storage.json
@@ -1,0 +1,6 @@
+{
+  "workingDir": "./temp/deploy/",
+  "account": "<!-- STORAGE ACCOUNT NAME -->",
+  "container": "pzl-site-page-header",
+  "accessKey": "<!-- ACCESS KEY -->"
+}

--- a/samples/react-pageheaderconfigurator/config/package-solution.json
+++ b/samples/react-pageheaderconfigurator/config/package-solution.json
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "name": "Site page header configurator by Puzzlepart",
+    "id": "ed347d47-519f-4f4c-b933-f1a1ec815f56",
+    "version": "1.0.0.0"
+  },
+  "paths": {
+    "zippedPackage": "solution/pzl-site-page-header.sppkg"
+  }
+}

--- a/samples/react-pageheaderconfigurator/config/serve.json
+++ b/samples/react-pageheaderconfigurator/config/serve.json
@@ -1,0 +1,9 @@
+{
+  "port": 4321,
+  "initialPage": "https://localhost:5432/workbench",
+  "https": true,
+  "api": {
+    "port": 5432,
+    "entryPath": "node_modules/@microsoft/sp-webpart-workbench/lib/api/"
+  }
+}

--- a/samples/react-pageheaderconfigurator/config/tslint.json
+++ b/samples/react-pageheaderconfigurator/config/tslint.json
@@ -1,0 +1,46 @@
+{
+  // Display errors as warnings
+  "displayAsWarning": true,
+  // The TSLint task may have been configured with several custom lint rules
+  // before this config file is read (for example lint rules from the tslint-microsoft-contrib
+  // project). If true, this flag will deactivate any of these rules.
+  "removeExistingRules": true,
+  // When true, the TSLint task is configured with some default TSLint "rules.":
+  "useDefaultConfigAsBase": false,
+  // Since removeExistingRules=true and useDefaultConfigAsBase=false, there will be no lint rules
+  // which are active, other than the list of rules below.
+  "lintConfig": {
+    // Opt-in to Lint rules which help to eliminate bugs in JavaScript
+    "rules": {
+      "class-name": false,
+      "export-name": false,
+      "forin": false,
+      "label-position": false,
+      "member-access": true,
+      "no-arg": false,
+      "no-console": false,
+      "no-construct": false,
+      "no-duplicate-case": true,
+      "no-duplicate-variable": true,
+      "no-eval": false,
+      "no-function-expression": true,
+      "no-internal-module": true,
+      "no-shadowed-variable": true,
+      "no-switch-case-fall-through": true,
+      "no-unnecessary-semicolons": true,
+      "no-unused-expression": true,
+      "no-unused-imports": true,
+      "no-use-before-declare": true,
+      "no-with-statement": true,
+      "semicolon": true,
+      "trailing-comma": false,
+      "typedef": false,
+      "typedef-whitespace": false,
+      "use-named-parameter": true,
+      "valid-typeof": true,
+      "variable-name": false,
+      "whitespace": false,
+      "prefer-const": true
+    }
+  }
+}

--- a/samples/react-pageheaderconfigurator/config/write-manifests.json
+++ b/samples/react-pageheaderconfigurator/config/write-manifests.json
@@ -1,0 +1,3 @@
+{
+  "cdnBasePath": "<!-- PATH TO CDN -->"
+}

--- a/samples/react-pageheaderconfigurator/gulpfile.js
+++ b/samples/react-pageheaderconfigurator/gulpfile.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const gulp = require('gulp');
+const build = require('@microsoft/sp-build-web');
+
+build.initialize(gulp);

--- a/samples/react-pageheaderconfigurator/package.json
+++ b/samples/react-pageheaderconfigurator/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "pzl-site-page-header",
+  "version": "0.0.1",
+  "private": true,
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "@microsoft/sp-client-base": "~1.0.0",
+    "@microsoft/sp-core-library": "~1.0.0",
+    "@microsoft/sp-webpart-base": "~1.0.0",
+    "@types/react": "0.14.46",
+    "@types/react-addons-shallow-compare": "0.14.17",
+    "@types/react-addons-test-utils": "0.14.15",
+    "@types/react-addons-update": "0.14.14",
+    "@types/react-dom": "0.14.18",
+    "@types/webpack-env": ">=1.12.1 <1.14.0",
+    "react": "15.4.2",
+    "react-dom": "15.4.2"
+  },
+  "devDependencies": {
+    "@microsoft/sp-build-web": "~1.0.0",
+    "@microsoft/sp-module-interfaces": "~1.0.0",
+    "@microsoft/sp-webpart-workbench": "~1.0.0",
+    "gulp": "~3.9.1",
+    "@types/chai": ">=3.4.34 <3.6.0",
+    "@types/mocha": ">=2.2.33 <2.6.0"
+  },
+  "scripts": {
+    "build": "gulp bundle",
+    "clean": "gulp clean",
+    "test": "gulp test"
+  }
+}

--- a/samples/react-pageheaderconfigurator/src/controls/PropertyPaneColorPicker/IPropertyPaneColorPickerInternalProps.ts
+++ b/samples/react-pageheaderconfigurator/src/controls/PropertyPaneColorPicker/IPropertyPaneColorPickerInternalProps.ts
@@ -1,0 +1,5 @@
+import { IPropertyPaneCustomFieldProps } from '@microsoft/sp-webpart-base';
+import { IPropertyPaneColorPickerProps } from './IPropertyPaneColorPickerProps';
+
+export interface IPropertyPaneColorPickerInternalProps extends IPropertyPaneColorPickerProps, IPropertyPaneCustomFieldProps {
+}

--- a/samples/react-pageheaderconfigurator/src/controls/PropertyPaneColorPicker/IPropertyPaneColorPickerProps.ts
+++ b/samples/react-pageheaderconfigurator/src/controls/PropertyPaneColorPicker/IPropertyPaneColorPickerProps.ts
@@ -1,0 +1,5 @@
+export interface IPropertyPaneColorPickerProps {
+  label: string;
+  onPropertyChange: (propertyPath: string, newValue: any) => void;
+  selectedColor: string;
+}

--- a/samples/react-pageheaderconfigurator/src/controls/PropertyPaneColorPicker/PropertyPaneColorPicker.ts
+++ b/samples/react-pageheaderconfigurator/src/controls/PropertyPaneColorPicker/PropertyPaneColorPicker.ts
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import * as ReactDom from 'react-dom';
+import {
+    IPropertyPaneField,
+    PropertyPaneFieldType
+} from '@microsoft/sp-webpart-base';
+import { IPropertyPaneColorPickerProps } from './IPropertyPaneColorPickerProps';
+import { IPropertyPaneColorPickerInternalProps } from './IPropertyPaneColorPickerInternalProps';
+import ColorPickerCtrl from './components/ColorPickerCtrl';
+import { IColorPickerCtrlProps } from './components/IColorPickerCtrlProps';
+
+export class PropertyPaneColorPicker implements IPropertyPaneField<IPropertyPaneColorPickerProps> {
+    public type: PropertyPaneFieldType = PropertyPaneFieldType.Custom;
+    public targetProperty: string;
+    public properties: IPropertyPaneColorPickerInternalProps;
+    private elem: HTMLElement;
+
+    constructor(targetProperty: string, properties: IPropertyPaneColorPickerProps) {
+        this.targetProperty = targetProperty;
+        this.properties = {
+            key: "custom",
+            label: properties.label,
+            onPropertyChange: properties.onPropertyChange,
+            selectedColor: properties.selectedColor,
+            onRender: this.onRender.bind(this)
+        };
+    }
+
+    public render(): void {
+        if (!this.elem) {
+            return;
+        }
+
+        this.onRender(this.elem);
+    }
+
+    private onRender(elem: HTMLElement): void {
+        if (!this.elem) {
+            this.elem = elem;
+        }
+
+        const element: React.ReactElement<IColorPickerCtrlProps> = React.createElement(ColorPickerCtrl, {
+            label: this.properties.label,
+            onColorChanged: this.onColorChanged.bind(this),
+            color: this.properties.selectedColor
+        });
+        ReactDom.render(element, elem);
+    }
+
+    private onColorChanged(color: string): void {
+        this.properties.onPropertyChange(this.targetProperty, color);
+    }
+}

--- a/samples/react-pageheaderconfigurator/src/controls/PropertyPaneColorPicker/components/ColorPickerCtrl.tsx
+++ b/samples/react-pageheaderconfigurator/src/controls/PropertyPaneColorPicker/components/ColorPickerCtrl.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { ColorPicker, Label } from 'office-ui-fabric-react';
+import { IColorPickerCtrlProps } from './IColorPickerCtrlProps';
+
+export default class ColorPickerCtrl extends React.Component<IColorPickerCtrlProps, void> {
+    constructor(props: IColorPickerCtrlProps) {
+        super(props);
+    }
+
+    public render(): JSX.Element {
+        if (this.props.color == null || this.props.color == '') {
+            this.props.color = "#333333";
+        }
+
+        return (
+            <div>
+                <Label>{this.props.label}</Label>
+                <ColorPicker color={this.props.color} alphaSliderHidden={true} onColorChanged={this.props.onColorChanged} />
+            </div>
+        );
+    }
+}

--- a/samples/react-pageheaderconfigurator/src/controls/PropertyPaneColorPicker/components/IColorPickerCtrlProps.ts
+++ b/samples/react-pageheaderconfigurator/src/controls/PropertyPaneColorPicker/components/IColorPickerCtrlProps.ts
@@ -1,0 +1,5 @@
+import { IColorPickerProps } from 'office-ui-fabric-react';
+
+export interface IColorPickerCtrlProps extends IColorPickerProps {
+  label: string;
+}

--- a/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/HeaderSize.ts
+++ b/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/HeaderSize.ts
@@ -1,0 +1,1 @@
+export enum HeaderSize { Large = 1, Medium, Small, None }

--- a/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/ISitePageHeaderConfiguratorWebPartProps.ts
+++ b/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/ISitePageHeaderConfiguratorWebPartProps.ts
@@ -1,0 +1,7 @@
+import { HeaderSize } from './HeaderSize';
+
+export interface ISitePageHeaderConfiguratorWebPartProps {
+  headerSize: HeaderSize;
+  headerGfx: string;
+  headerFontColor: string;
+}

--- a/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/SitePageHeaderConfiguratorWebPart.manifest.json
+++ b/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/SitePageHeaderConfiguratorWebPart.manifest.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../../node_modules/@microsoft/sp-module-interfaces/lib/manifestSchemas/jsonSchemas/clientSideComponentManifestSchema.json",
+  "id": "ed5bdd3b-c869-4d76-9cd3-0de041339898",
+  "alias": "SitePageHeaderConfiguratorWebPart",
+  "componentType": "WebPart",
+  "version": "0.0.1",
+  "manifestVersion": 2,
+  "preconfiguredEntries": [
+    {
+      "groupId": "ed5bdd3b-c869-4d76-9cd3-0de041339898",
+      "group": {
+        "default": "Page Improvements"
+      },
+      "title": {
+        "default": "Page header configurator"
+      },
+      "description": {
+        "default": "Configure how to display the header of a site page"
+      },
+      "officeFabricIconFontName": "AutoEnhanceOn",
+      "properties": {
+        "headerSize": 1,
+        "headerGfx": "",
+        "headerFontColor": "#333333"
+      }
+    }
+  ]
+}

--- a/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/SitePageHeaderConfiguratorWebPart.ts
+++ b/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/SitePageHeaderConfiguratorWebPart.ts
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import * as ReactDom from 'react-dom';
+import { Version, DisplayMode } from '@microsoft/sp-core-library';
+import {
+  BaseClientSideWebPart,
+  IPropertyPaneConfiguration,
+  PropertyPaneTextField,
+  PropertyPaneChoiceGroup
+} from '@microsoft/sp-webpart-base';
+
+import * as strings from 'sitePageHeaderConfiguratorStrings';
+import SitePageHeaderConfiguratorEdit from './components/SitePageHeaderConfiguratorEdit';
+import SitePageHeaderConfiguratorView from './components/SitePageHeaderConfiguratorView';
+import { ISitePageHeaderConfiguratorProps } from './components/ISitePageHeaderConfiguratorProps';
+import { ISitePageHeaderConfiguratorWebPartProps } from './ISitePageHeaderConfiguratorWebPartProps';
+import { PropertyPaneColorPicker } from '../../controls/PropertyPaneColorPicker/PropertyPaneColorPicker';
+import { update, get } from '@microsoft/sp-lodash-subset';
+
+export default class SitePageHeaderConfiguratorWebPart extends BaseClientSideWebPart<ISitePageHeaderConfiguratorWebPartProps> {
+
+  private onListChange(propertyPath: string, newValue: any): void {
+    const oldValue: any = get(this.properties, propertyPath);
+    // store new value in web part properties
+    update(this.properties, propertyPath, (): any => { return newValue; });
+    // refresh web part
+    this.onPropertyPaneFieldChanged(propertyPath, oldValue, newValue);
+  }
+
+  public render(): void {
+    const editElement: React.ReactElement<ISitePageHeaderConfiguratorProps> = React.createElement(
+      SitePageHeaderConfiguratorEdit,
+      {
+        headerSize: this.properties.headerSize,
+        headerGfx: this.properties.headerGfx,
+        headerFontColor: this.properties.headerFontColor
+      }
+    );
+
+    const viewElement: React.ReactElement<ISitePageHeaderConfiguratorProps> = React.createElement(
+      SitePageHeaderConfiguratorView,
+      {
+        headerSize: this.properties.headerSize,
+        headerGfx: this.properties.headerGfx,
+        headerFontColor: this.properties.headerFontColor
+      }
+    );
+
+
+    if (this.displayMode == DisplayMode.Edit) {
+      ReactDom.render(editElement, this.domElement);
+    } else {
+      ReactDom.render(viewElement, this.domElement);
+    }
+  }
+
+  protected get dataVersion(): Version {
+    return Version.parse('1.0');
+  }
+
+  protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
+    return {
+      pages: [
+        {
+          groups: [
+            {
+              groupFields: [
+                PropertyPaneChoiceGroup('headerSize',
+                  {
+                    label: "Header size",
+                    options: [{ key: 1, text: strings.Large }, { key: 2, text: strings.Medium }, { key: 3, text: strings.Small }, { key: 4, text: strings.None }]
+                  }
+                ),
+
+                PropertyPaneTextField('headerGfx', {
+                  label: "URL",
+                  description: "URL to header graphics Graphics (will be scaled)"
+                })
+                ,
+
+                new PropertyPaneColorPicker('headerFontColor', {
+                  label: "Headline color",
+                  onPropertyChange: this.onListChange.bind(this),
+                  selectedColor: this.properties.headerFontColor
+                })
+              ]
+            }
+          ]
+        }
+      ]
+    };
+  }
+}

--- a/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/components/ISitePageHeaderConfiguratorProps.ts
+++ b/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/components/ISitePageHeaderConfiguratorProps.ts
@@ -1,0 +1,7 @@
+import { HeaderSize } from '../HeaderSize';
+
+export interface ISitePageHeaderConfiguratorProps {
+  headerSize: HeaderSize;
+  headerGfx: string;
+  headerFontColor: string;
+}

--- a/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/components/SitePageHeaderConfigurator.module.scss
+++ b/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/components/SitePageHeaderConfigurator.module.scss
@@ -1,0 +1,52 @@
+.helloWorld {
+  .container {
+    max-width: 700px;
+    margin: 0px auto;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .row {
+    padding: 20px;
+  }
+
+  .listItem {
+    max-width: 715px;
+    margin: 5px auto 5px auto;
+    box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .button {
+    // Our button
+    text-decoration: none;
+    height: 32px;
+
+    // Primary Button
+    min-width: 80px;
+    background-color: #0078d7;
+    border-color: #0078d7;
+    color: #ffffff;
+
+    // Basic Button
+    outline: transparent;
+    position: relative;
+    font-family: "Segoe UI WestEuropean","Segoe UI",-apple-system,BlinkMacSystemFont,Roboto,"Helvetica Neue",sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    font-weight: 400;
+    border-width: 0;
+    text-align: center;
+    cursor: pointer;
+    display: inline-block;
+    padding: 0 16px;
+
+    .label {
+      font-weight: 600;
+      font-size: 14px;
+      height: 32px;
+      line-height: 32px;
+      margin: 0 4px;
+      vertical-align: top;
+      display: inline-block;
+    }
+  }
+}

--- a/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/components/SitePageHeaderConfiguratorEdit.tsx
+++ b/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/components/SitePageHeaderConfiguratorEdit.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import styles from './SitePageHeaderConfigurator.module.scss';
+import { ISitePageHeaderConfiguratorProps } from './ISitePageHeaderConfiguratorProps';
+import { escape } from '@microsoft/sp-lodash-subset';
+import { HeaderSize } from '../HeaderSize';
+import SitePageHeaderConfiguratorView from './SitePageHeaderConfiguratorView';
+
+export default class SitePageHeaderConfiguratorEdit extends React.Component<ISitePageHeaderConfiguratorProps, void> {
+  public render(): React.ReactElement<ISitePageHeaderConfiguratorProps> {
+    let gfxSetting = <span />;
+
+    if (this.props.headerFontColor == null || this.props.headerFontColor == '') {
+      this.props.headerFontColor = "#333333";
+    }
+
+    const viewElement: React.ReactElement<ISitePageHeaderConfiguratorProps> = React.createElement(
+      SitePageHeaderConfiguratorView,
+      {
+        headerSize: this.props.headerSize,
+        headerGfx: this.props.headerGfx,
+        headerFontColor: this.props.headerFontColor
+      }
+    );
+
+    const headlineColorStyle = {
+      backgroundColor: this.props.headerFontColor,
+      height: '15px',
+      width: '15px',
+      display: 'inline-block',
+      margin: '0px 10px',
+      position: 'absolute',
+      border: 'solid 1px white'
+    };
+
+    if (this.props.headerGfx != null && this.props.headerGfx.indexOf('https://') >= 0) {
+      gfxSetting = <p className="ms-fontColor-white">
+        <div className="ms-font-l ms-fontWeight-semibold">Header background graphics</div>
+        <div className="ms-font-mPlus">{escape(this.props.headerGfx)}</div>
+      </p>;
+    }
+
+    return (
+      <div className={styles.helloWorld}>
+        <div className={styles.container}>
+          <div className={`ms-Grid-row ms-bgColor-themeDark ms-fontColor-white ${styles.row}`}>
+            <div className="ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1">
+              <span className="ms-font-xl ms-fontColor-white">Page header settings</span>
+              <p className="ms-fontColor-white">
+                <div className="ms-font-l ms-fontWeight-semibold">Header size</div>
+                <div className="ms-font-mPlus">{HeaderSize[this.props.headerSize]}</div>
+              </p>
+              <p className="ms-fontColor-white">
+                <div className="ms-font-l ms-fontWeight-semibold">Headline color</div>
+                <div className="ms-font-mPlus">{this.props.headerFontColor}
+                  <div style={headlineColorStyle}></div>
+                </div>
+              </p>
+              {gfxSetting}
+            </div>
+          </div>
+        </div>
+        {viewElement}
+      </div>
+    );
+  }
+}

--- a/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/components/SitePageHeaderConfiguratorView.tsx
+++ b/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/components/SitePageHeaderConfiguratorView.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { ISitePageHeaderConfiguratorProps } from './ISitePageHeaderConfiguratorProps';
+import { HeaderSize } from '../HeaderSize';
+
+export default class SitePageHeaderConfiguratorView extends React.Component<ISitePageHeaderConfiguratorProps, void> {
+  public render(): React.ReactElement<ISitePageHeaderConfiguratorProps> {
+    let gfxOverrideStyle: string = "";
+    let headerHeight: number;
+    if (this.props.headerSize == HeaderSize.Medium) {
+      headerHeight = 114;
+    } else if (this.props.headerSize == HeaderSize.Small) {
+      headerHeight = 70;
+    } else if (this.props.headerSize == HeaderSize.None) {
+      headerHeight = 0;
+    }
+
+    let headerStyle: string = `
+      .pageHeader .headerTitleText {
+        color: ${this.props.headerFontColor} !important
+      }
+      `;
+    if (this.props.headerSize != HeaderSize.Large) {
+      headerStyle += `
+      .pageHeader {
+        height: ${headerHeight}px !important;
+      }
+      `;
+    }
+
+    if (this.props.headerSize != HeaderSize.None
+      && this.props.headerGfx != null
+      && this.props.headerGfx.indexOf('https://') >= 0) {
+      gfxOverrideStyle = `
+      .pageHeader {
+        background-image: url(${this.props.headerGfx}) !important
+      }
+      .pageHeader:not(.pageHeaderEdit):before {
+        background-image: url(${this.props.headerGfx})
+      }
+`;
+    }
+
+    return (
+      <style dangerouslySetInnerHTML={{
+        __html: headerStyle + gfxOverrideStyle
+      }}>{
+        }
+      </style>
+    );
+  }
+}

--- a/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/loc/en-us.js
+++ b/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/loc/en-us.js
@@ -1,0 +1,11 @@
+define([], function() {
+  return {
+    "PropertyPaneDescription": "Description",
+    "BasicGroupName": "Group Name",
+    "DescriptionFieldLabel": "Description Field",
+    "Large" : "Large",
+    "Medium" : "Medium",
+    "Small" : "Small",
+    "None" : "None",
+  }
+});

--- a/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/loc/mystrings.d.ts
+++ b/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/loc/mystrings.d.ts
@@ -1,0 +1,14 @@
+declare interface ISitePageHeaderConfiguratorStrings {
+  PropertyPaneDescription: string;
+  BasicGroupName: string;
+  DescriptionFieldLabel: string;
+  Large: string;
+  Medium: string;
+  Small: string;
+  None: string;
+}
+
+declare module 'sitePageHeaderConfiguratorStrings' {
+  const strings: ISitePageHeaderConfiguratorStrings;
+  export = strings;
+}

--- a/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/tests/SitePageHeaderConfigurator.test.ts
+++ b/samples/react-pageheaderconfigurator/src/webparts/sitePageHeaderConfigurator/tests/SitePageHeaderConfigurator.test.ts
@@ -1,0 +1,9 @@
+/// <reference types="mocha" />
+
+import { assert } from 'chai';
+
+describe('SitePageHeaderConfiguratorWebPart', () => {
+  it('should do something', () => {
+    assert.ok(true);
+  });
+});

--- a/samples/react-pageheaderconfigurator/tsconfig.json
+++ b/samples/react-pageheaderconfigurator/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "forceConsistentCasingInFileNames": true,
+    "module": "commonjs",
+    "jsx": "react",
+    "declaration": true,
+    "sourceMap": true,
+    "types": [
+      "es6-promise",
+      "es6-collections",
+      "webpack-env"
+    ]
+  }
+}

--- a/samples/react-pageheaderconfigurator/typings/@ms/odsp.d.ts
+++ b/samples/react-pageheaderconfigurator/typings/@ms/odsp.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for Microsoft ODSP projects
+// Project: ODSP
+
+/* Global definition for UNIT_TEST builds
+   Code that is wrapped inside an if(UNIT_TEST) {...}
+   block will not be included in the final bundle when the
+   --ship flag is specified */
+declare const UNIT_TEST: boolean;

--- a/samples/react-pageheaderconfigurator/typings/tsd.d.ts
+++ b/samples/react-pageheaderconfigurator/typings/tsd.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="@ms/odsp.d.ts" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New sample?      | yes

#### What's in this Pull Request?

Sample which uses an Office UI fabric color picker in the property pane, and allows configuration of the header/banner of a modern site page.