### PR TITLE
react-bot-framework Sample - Fix to main Input.

### DIFF
--- a/samples/react-bot-framework/src/webparts/botFrameworkChat/BotFrameworkChat.module.scss
+++ b/samples/react-bot-framework/src/webparts/botFrameworkChat/BotFrameworkChat.module.scss
@@ -53,6 +53,5 @@
   .messageBox input {
     border: 3px #c8c8c8 solid !important;
     border-collapse: collapse;
-    padding: 15px;
   }
 }


### PR DESCRIPTION
The field was not showing the text on IE because of a padding issue.

| Q               | A
| --------------- | ---
| Bug fix?        | Yes
| New feature?    | No
| New sample?      | No
| Related issues?  | No issue associated

The sample had a issue on IE, since the main input that allows the user interact with the bot was not showing the text on IE because of a padding (Edge / Chrome were not affected). Our team found the issue and fixed it.. (We just removed the padding without affecting the functionality of the sample. making it usable on IE/Edge/Chrome

Thanks