### PR TITLE
Support of both Fabric < 6.0.0 and 6.0.0

### DIFF
--- a/samples/react-side-panel/src/webparts/sidePanel/components/WebPart/SidePanel.tsx
+++ b/samples/react-side-panel/src/webparts/sidePanel/components/WebPart/SidePanel.tsx
@@ -25,7 +25,7 @@ export default class SidePanel extends React.Component<ISidePanelProps, ISidePan
       <div className={styles.helloWorld}>
         <div className={styles.container}>
           <div className={`ms-Grid-row ms-bgColor-themeDark ms-fontColor-white ${styles.row}`}>
-            <div className="ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1">
+            <div className="ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1 ms-lg10 ms-xl8 ms-xlPush2 ms-lgPush1">
               <p className="ms-font-l ms-fontColor-white">This Web Part shows how to open a side panel.</p>
               <p className="ms-font-l ms-fontColor-white">Please, click the button below.</p>
               <Button onClick={this.onButtonClick.bind(this)} buttonType={ButtonType.default}>{this.state.isOpen ? 'Hide Panel' : 'Show Panel'}</Button>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| New sample?      | no
| Related issues?  | no

#### What's in this Pull Request?

Code of React Side Panel web part was updated to use css classes prefixed with `ms-u-` (Fabric < 6.0.0) and `ms-` (Fabric 6.0.0)
