### PR TITLE
fix bug by correcting the separator character

### DIFF
--- a/samples/react-aad-implicitflow/src/webparts/WebPartAuthenticationContext.js
+++ b/samples/react-aad-implicitflow/src/webparts/WebPartAuthenticationContext.js
@@ -51,7 +51,7 @@ AuthenticationContext.prototype._renewToken = function (resource, callback) {
   this._renewTokenSuper(resource, callback);
   var _renewStates = this._getItem('renewStates');
   if (_renewStates) {
-    _renewStates = _renewStates.split(';');
+    _renewStates = _renewStates.split(',');
   }
   else {
     _renewStates = [];


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | mentioned in #150  

#### What's in this Pull Request?

This update replaces the incorrect semi-colon separator with the correct comma separator. Without a correction, it is possible to encounter issues such as token renewal timeout or token renewal silent failure. Testing included turning on logging in adal-angular.js to observe changes.

When the existing array _renewStates is cast as a string (at the string.prototype.split() function or possibly in earlier code), that existing array is represented as "A String, representing the values of the array, separated by a comma" [quote source](https://www.w3schools.com/jsref/jsref_tostring_array.asp).
