### PR TITLE
[react-textboxio] Bug fix ("can't read property 'getAttribute' of null")

### DIFF
--- a/samples/react-textboxio/src/webparts/textboxioEditor/components/TextboxioEditor.tsx
+++ b/samples/react-textboxio/src/webparts/textboxioEditor/components/TextboxioEditor.tsx
@@ -25,25 +25,13 @@ export default class TextboxioEditor extends React.Component<ITextboxioEditorPro
         }
     }
 
-    public render() {
-
-        let renderHtml: JSX.Element = null;
+    public render() {        
         
-        if (this.props.displayMode === DisplayMode.Read) {
-
-            renderHtml = <div dangerouslySetInnerHTML={ {__html: this.props.content } }></div>;
-
-        } else {
-            renderHtml =  
-
-            <div className={ styles.editor } 
-                 ref={ (ref)=> {
-                    this._refEditor = ref;
-                }} id={ "textbox-io-editor-" + this. _getNewGuid() }>
-            </div>
-        }
-
-        return renderHtml;
+        return  <div className={ styles.editor } 
+                        ref={ (ref)=> {
+                        this._refEditor = ref;
+                    }} id={ "textbox-io-editor-" + this. _getNewGuid() }>
+                </div>;
     }
 
     public componentDidMount() {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes

#### What's in this Pull Request?

Fixed a bug when switching from edit to display mode. The error was "can't read property 'getAttribute' of null" due to a null reference.