### PR TITLE
Fix multiple filters not working properly if one of them is type IsNull/IsNotNull and others aren't.

### DIFF
--- a/samples/react-content-query-webpart/src/common/helpers/CamlQueryHelper.ts
+++ b/samples/react-content-query-webpart/src/common/helpers/CamlQueryHelper.ts
@@ -62,12 +62,13 @@ export class CamlQueryHelper {
         
         // Store the generic filter format for later use
         let query = '';
-        let filterXml = '<{0}><FieldRef Name="{1}" /><Value {2} Type="{3}">{4}</Value></{0}>';
+        let filterXml = '';
 
         // Appends a CAML node for each filter
         let itemCount = 0;
 
         for(let filter of filters.reverse()) {
+            filterXml = '<{0}><FieldRef Name="{1}" /><Value {2} Type="{3}">{4}</Value></{0}>';
             itemCount++;
             let specialAttribute = '';
 


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? |  |

## What's in this Pull Request?

> Current code is setting the filterXml template string outside of the filter processing loop. The first time an IsNull/IsNotNull filter is encountered, filterXml is set to a different template that excludes the value portion of the filter, and from there out, it'll end up getting applied to all the rest of the filters incorrectly. Fix simply sets the initial template inside the loop instead of outside it so that it's reset to the proper initial template each time a new filter starts getting processed.
