### PR TITLE
React-events-aggregator sample, wp manifest.json schema URLs updated

### DIFF
--- a/samples/react-events-aggregator/src/webparts/broadcaster/BroadcasterWebPart.manifest.json
+++ b/samples/react-events-aggregator/src/webparts/broadcaster/BroadcasterWebPart.manifest.json
@@ -1,13 +1,11 @@
 {
-  "$schema": "../../../node_modules/@microsoft/sp-module-interfaces/lib/manifestSchemas/jsonSchemas/clientSideComponentManifestSchema.json",
-
+  "$schema": "https://dev.office.com/json-schemas/spfx/client-side-web-part-manifest.schema.json",
   "id": "d0c6977d-b995-46ff-a246-14ff43495e0e",
   "alias": "BroadcasterWebPart",
   "componentType": "WebPart",
   "version": "*",
   "manifestVersion": 2,
-  "safeWithCustomScriptDisabled": false,
-
+  "requiresCustomScript": false,
   "preconfiguredEntries": [{
     "groupId": "d0c6977d-b995-46ff-a246-14ff43495e0e",
     "group": { "default": "Under Development" },

--- a/samples/react-events-aggregator/src/webparts/receiver/ReceiverWebPart.manifest.json
+++ b/samples/react-events-aggregator/src/webparts/receiver/ReceiverWebPart.manifest.json
@@ -1,13 +1,11 @@
 {
-  "$schema": "../../../node_modules/@microsoft/sp-module-interfaces/lib/manifestSchemas/jsonSchemas/clientSideComponentManifestSchema.json",
-
+  "$schema": "https://dev.office.com/json-schemas/spfx/client-side-web-part-manifest.schema.json",
   "id": "891b997e-67da-4da3-a6e1-3caf8bb264be",
   "alias": "ReceiverWebPart",
   "componentType": "WebPart",
   "version": "*",
   "manifestVersion": 2,
-  "safeWithCustomScriptDisabled": false,
-
+  "requiresCustomScript": false,
   "preconfiguredEntries": [{
     "groupId": "891b997e-67da-4da3-a6e1-3caf8bb264be",
     "group": { "default": "Under Development" },


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                              |
| New feature?    | yes                              |
| New sample?     | no                              |
| Related issues? | fixes #X, partially #Y, mentioned in #Z |

## What's in this Pull Request?

I updated the webparts manifest.json schema URLs to reflect the 1.4.1 version of the manifest.json. I updated the sample to 1.4.1 in my last commit, but forgot to update the urls. The sample is still running ok without that change, but it is good to have those urls updated as well.
