### PR TITLE
Fixed blanking out entire page when user lacks permissions on template and SP returns access denied page

### DIFF
--- a/samples/react-content-query-webpart/src/common/services/ContentQueryService.ts
+++ b/samples/react-content-query-webpart/src/common/services/ContentQueryService.ts
@@ -134,7 +134,13 @@ export class ContentQueryService implements IContentQueryService {
         return new Promise<string>((resolve,reject) => {
             this.spHttpClient.get(fileUrl, SPHttpClient.configurations.v1).then((response: SPHttpClientResponse) => {
                 if(response.ok) {
-                    resolve(response.text());
+                    if(response.url.indexOf('AccessDenied.aspx') > -1){
+                        reject('Access Denied');
+                    }
+                    else
+                    {
+                        resolve(response.text());
+                    }                    
                 }
                 else {
                     reject(response.statusText);


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? |  |

## What's in this Pull Request?

Currently, if the current user does not have access to the template specified by URL because it's in a SharePoint library they don't have permissions on, SharePoint's custom Access Denied page is returned, and the web part tries to load it up as the template, causing the entire page to go completely white. Added a check for that page in the response URL and return an appropriate error when it happens.
