### PR TITLE
Fixed filters not sorting correctly in IE/Edge

### DIFF
--- a/samples/react-content-query-webpart/src/common/helpers/CamlQueryHelper.ts
+++ b/samples/react-content-query-webpart/src/common/helpers/CamlQueryHelper.ts
@@ -19,7 +19,7 @@ export class CamlQueryHelper {
 
         // Generates the <Where /> part
         if(querySettings.filters && !isEmpty(querySettings.filters)) {
-            let sortedFilters = querySettings.filters.sort((a, b) => { if(a.index > b.index) { return 1; } else { return 0; } });
+            let sortedFilters = querySettings.filters.sort((a, b) => { return a.index - b.index; });
             query += Text.format('<Where>{0}</Where>', this.generateFilters(sortedFilters));
         }
 


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                              |
| New sample?     | no                              |
| Related issues? |  |

## What's in this Pull Request?

Current code is sorting the filters with a function that doesn't sort properly in IE / Edge, causing the filters to get applied in an incorrect order.

You can verify the improper sorting by running the following javascript in the IE console:

// Fixed, valid sorting
var array1 = [1,2,3,4];
var array2 = [2,4,3,1];

array1.sort(function(a, b) { return a - b; });
array2.sort(function(a, b) { return a - b; });
console.log(array1);
console.log(array2);


// Old  invalid sorting
array1 = [1,2,3,4];
array2 = [2,4,3,1];

array1.sort(function(a, b) { if (a > b) { return 1; } else { return 0; } });
array2.sort(function(a, b) { if (a > b) { return 1; } else { return 0; } });
console.log(array1);
console.log(array2);