### PR TITLE
[react-todo-basic] Fixed "immutability-helper" npm package version

### DIFF
--- a/samples/react-todo-basic/package.json
+++ b/samples/react-todo-basic/package.json
@@ -16,7 +16,7 @@
     "@types/react-addons-shallow-compare": "0.14.17",
     "@types/react-addons-update": "0.14.14",
     "@types/react-addons-test-utils": "0.14.15",
-    "immutability-helper": "^2.2.0"
+    "immutability-helper": "2.2.0"
   },
   "devDependencies": {
     "@microsoft/sp-build-web": "~1.1.0",


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                             |

Fixed _"immutability-helper"_ npm package version in the _package.json_ file. When a a **npm i** was executed, the latest version of this package was retrieved due to the "caret" causing typings issues.

Related issue: https://github.com/SharePoint/sp-dev-fx-webparts/issues/500