### PR TITLE
React Jest Testing - Upgrade to 1.5.0, missing launch.json config added

### DIFF
--- a/samples/react-jest-testing/.yo-rc.json
+++ b/samples/react-jest-testing/.yo-rc.json
@@ -1,8 +1,11 @@
 {
   "@microsoft/generator-sharepoint": {
-    "version": "1.4.1",
+    "isCreatingSolution": true,
+    "version": "1.5.0",
     "libraryName": "react-jest-testing",
     "libraryId": "9e16e13b-8d8c-4b89-8de4-dd654c5b6740",
-    "environment": "spo"
+    "environment": "spo",
+    "packageManager": "npm",
+    "componentType": "webpart"
   }
 }

--- a/samples/react-jest-testing/README.md
+++ b/samples/react-jest-testing/README.md
@@ -15,6 +15,10 @@ There is also a _Jest Watch_ (watcher) configuration that **will let live execut
 
 ![SharePoint Framework Jest Visual Studio Code - debugging unit test](./assets/Jest-Typescript-VSCode-debugging.png)
 
+### Important: The dedug configurations should be placed in the .vscode -> launch.json file to make the debugging work
+
+The sample has folder named `vscode` where the `launch.json` configuration for debuggind jest is stored. The configurations should be copied to your `.vscode` folder -> `launch.json` file. Once copied into your launch.json, then they will appear in your visual studio code debugging tab.
+
 ## Sinonjs is included as mocking framework for the SPFx solution
 
 The solution also includes [Sinonjs](http://sinonjs.org/) that can be used to spawn spies, stubs and mocks.
@@ -58,7 +62,7 @@ The sample uses SPFx web part, but the same setup applies for SPFx extensions an
 
 
 ## Used SharePoint Framework Version 
-![drop](https://img.shields.io/badge/drop-1.4.1-green.svg)
+![drop](https://img.shields.io/badge/drop-1.5.0-green.svg)
 
 ## Applies to
 
@@ -81,6 +85,7 @@ react-jest-testing | Velin Georgiev ( [@VelinGeorgiev](https://twitter.com/velin
 Version|Date|Comments
 -------|----|--------
 0.0.1|May 9, 2018 | Initial commit
+0.0.2|June 12, 2018 | Update to 1.5.0, missing launch.json added
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/samples/react-jest-testing/config/config.json
+++ b/samples/react-jest-testing/config/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://dev.office.com/json-schemas/spfx-build/config.2.0.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/config.2.0.schema.json",
   "version": "2.0",
   "bundles": {
     "ice-cream-shop-web-part": {

--- a/samples/react-jest-testing/config/copy-assets.json
+++ b/samples/react-jest-testing/config/copy-assets.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://dev.office.com/json-schemas/spfx-build/copy-assets.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/copy-assets.schema.json",
   "deployCdnPath": "temp/deploy"
 }

--- a/samples/react-jest-testing/config/deploy-azure-storage.json
+++ b/samples/react-jest-testing/config/deploy-azure-storage.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://dev.office.com/json-schemas/spfx-build/deploy-azure-storage.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/deploy-azure-storage.schema.json",
   "workingDir": "./temp/deploy/",
   "account": "<!-- STORAGE ACCOUNT NAME -->",
   "container": "react-jest-testing",

--- a/samples/react-jest-testing/config/package-solution.json
+++ b/samples/react-jest-testing/config/package-solution.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://dev.office.com/json-schemas/spfx-build/package-solution.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/package-solution.schema.json",
   "solution": {
     "name": "react-jest-testing-client-side-solution",
     "id": "9e16e13b-8d8c-4b89-8de4-dd654c5b6740",

--- a/samples/react-jest-testing/config/serve.json
+++ b/samples/react-jest-testing/config/serve.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://dev.office.com/json-schemas/core-build/serve.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/core-build/serve.schema.json",
   "port": 4321,
   "https": true,
   "initialPage": "https://localhost:5432/workbench",

--- a/samples/react-jest-testing/config/tslint.json
+++ b/samples/react-jest-testing/config/tslint.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://dev.office.com/json-schemas/core-build/tslint.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/core-build/tslint.schema.json",
   // Display errors as warnings
   "displayAsWarning": true,
   // The TSLint task may have been configured with several custom lint rules

--- a/samples/react-jest-testing/config/write-manifests.json
+++ b/samples/react-jest-testing/config/write-manifests.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://dev.office.com/json-schemas/spfx-build/write-manifests.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/write-manifests.schema.json",
   "cdnBasePath": "<!-- PATH TO CDN -->"
 }

--- a/samples/react-jest-testing/package-lock.json
+++ b/samples/react-jest-testing/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jest-testing",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -61,36 +61,90 @@
         }
       }
     },
-    "@microsoft/api-extractor": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-4.2.6.tgz",
-      "integrity": "sha1-LEQcgMR1AO/lG49ICH+gNkAGC5U=",
+    "@gulp-sourcemaps/identity-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.1.tgz",
+      "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
       "dev": true,
       "requires": {
-        "@microsoft/node-core-library": "0.3.16",
-        "@microsoft/ts-command-line": "2.2.4",
-        "@types/fs-extra": "0.0.37",
-        "@types/node": "6.0.88",
+        "acorn": "5.6.2",
+        "css": "2.2.3",
+        "normalize-path": "2.1.1",
+        "source-map": "0.5.7",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.6.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
+          "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
+          "dev": true
+        }
+      }
+    },
+    "@gulp-sourcemaps/map-sources": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+      "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
+      "dev": true,
+      "requires": {
+        "normalize-path": "2.1.1",
+        "through2": "2.0.3"
+      }
+    },
+    "@microsoft/api-extractor": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-5.6.5.tgz",
+      "integrity": "sha1-dQ/Um66u3ad3qAg2tTfflXE8uK4=",
+      "dev": true,
+      "requires": {
+        "@microsoft/node-core-library": "1.2.0",
+        "@microsoft/ts-command-line": "4.0.0",
+        "@types/fs-extra": "5.0.1",
+        "@types/node": "8.5.8",
         "@types/z-schema": "3.16.31",
-        "colors": "1.1.2",
-        "fs-extra": "0.26.7",
+        "colors": "1.2.5",
+        "fs-extra": "5.0.0",
         "jju": "1.3.0",
         "lodash": "4.15.0",
         "typescript": "2.4.2",
         "z-schema": "3.18.4"
       },
       "dependencies": {
+        "@types/fs-extra": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
+          "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "8.5.8"
+          }
+        },
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
           "dev": true
         },
-        "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-          "dev": true
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
         },
         "lodash": {
           "version": "4.15.0",
@@ -101,27 +155,27 @@
       }
     },
     "@microsoft/decorators": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/decorators/-/decorators-1.4.1.tgz",
-      "integrity": "sha1-fWE/7dik03ntBRzXEU8fyUGa8jY=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/decorators/-/decorators-1.5.0.tgz",
+      "integrity": "sha1-Z8UbndvOho5vnoAj03PB4vDhdDg=",
       "requires": {
         "tslib": "1.8.1"
       }
     },
     "@microsoft/gulp-core-build": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-3.2.7.tgz",
-      "integrity": "sha1-c+Gh6dokBVxvoBxjcu8u+X+gejw=",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-3.7.4.tgz",
+      "integrity": "sha1-7eUOORi2dygtZIZlEPELpwqLLNU=",
       "dev": true,
       "requires": {
-        "@microsoft/node-core-library": "0.3.16",
+        "@microsoft/node-core-library": "1.2.0",
         "@types/assertion-error": "1.0.30",
         "@types/chai": "3.4.34",
         "@types/chalk": "0.4.31",
         "@types/gulp": "3.8.32",
         "@types/gulp-util": "3.0.30",
         "@types/mocha": "2.2.38",
-        "@types/node": "6.0.88",
+        "@types/node": "8.5.8",
         "@types/node-notifier": "0.0.28",
         "@types/orchestrator": "0.0.30",
         "@types/q": "0.0.32",
@@ -130,6 +184,7 @@
         "@types/through2": "2.0.32",
         "@types/vinyl": "1.2.30",
         "@types/yargs": "0.0.34",
+        "colors": "1.2.5",
         "del": "2.2.2",
         "end-of-stream": "1.1.0",
         "fs-extra": "0.26.7",
@@ -139,8 +194,10 @@
         "gulp-flatten": "0.2.0",
         "gulp-if": "2.0.2",
         "gulp-util": "3.0.8",
-        "jest": "20.0.4",
-        "jest-cli": "20.0.4",
+        "jest": "21.2.1",
+        "jest-cli": "21.2.1",
+        "jest-environment-jsdom": "21.2.1",
+        "jest-resolve": "21.2.0",
         "jju": "1.3.0",
         "lodash.merge": "4.3.5",
         "merge2": "1.0.3",
@@ -155,42 +212,380 @@
         "z-schema": "3.18.4"
       },
       "dependencies": {
-        "@types/chai": {
-          "version": "3.4.34",
-          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.4.34.tgz",
-          "integrity": "sha1-1TNXkoI7sJzd1eOMPSEbcJGDhU0=",
-          "dev": true
-        },
-        "@types/mocha": {
-          "version": "2.2.38",
-          "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.38.tgz",
-          "integrity": "sha1-jBiPbjTC58Px0BJ9kI1aNuWmDck=",
-          "dev": true
-        },
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
           "dev": true
         },
-        "jest": {
-          "version": "20.0.4",
-          "resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
-          "integrity": "sha1-PdJgwpidba1nix6cxNkZRPbWAqw=",
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "jest-cli": "20.0.4"
+            "color-convert": "1.9.1"
+          }
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "jest": {
+          "version": "21.2.1",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-21.2.1.tgz",
+          "integrity": "sha512-mXN0ppPvWYoIcC+R+ctKxAJ28xkt/Z5Js875padm4GbgUn6baeR5N4Ng6LjatIRpUQDZVJABT7Y4gucFjPryfw==",
+          "dev": true,
+          "requires": {
+            "jest-cli": "21.2.1"
+          }
+        },
+        "jest-cli": {
+          "version": "21.2.1",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.2.1.tgz",
+          "integrity": "sha512-T1BzrbFxDIW/LLYQqVfo94y/hhaj1NzVQkZgBumAC+sxbjMROI7VkihOdxNR758iYbQykL2ZOWUBurFgkQrzdg==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.4.1",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "is-ci": "1.1.0",
+            "istanbul-api": "1.3.1",
+            "istanbul-lib-coverage": "1.2.0",
+            "istanbul-lib-instrument": "1.10.1",
+            "istanbul-lib-source-maps": "1.2.3",
+            "jest-changed-files": "21.2.0",
+            "jest-config": "21.2.1",
+            "jest-environment-jsdom": "21.2.1",
+            "jest-haste-map": "21.2.0",
+            "jest-message-util": "21.2.1",
+            "jest-regex-util": "21.2.0",
+            "jest-resolve-dependencies": "21.2.0",
+            "jest-runner": "21.2.1",
+            "jest-runtime": "21.2.1",
+            "jest-snapshot": "21.2.1",
+            "jest-util": "21.2.1",
+            "micromatch": "2.3.11",
+            "node-notifier": "5.0.2",
+            "pify": "3.0.0",
+            "slash": "1.0.0",
+            "string-length": "2.0.0",
+            "strip-ansi": "4.0.0",
+            "which": "1.3.0",
+            "worker-farm": "1.6.0",
+            "yargs": "9.0.1"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "9.0.1",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+              "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+              "dev": true,
+              "requires": {
+                "camelcase": "4.1.0",
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "read-pkg-up": "2.0.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "7.0.0"
+              }
+            }
+          }
+        },
+        "jest-runner": {
+          "version": "21.2.1",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.2.1.tgz",
+          "integrity": "sha512-Anb72BOQlHqF/zETqZ2K20dbYsnqW/nZO7jV8BYENl+3c44JhMrA8zd1lt52+N7ErnsQMd2HHKiVwN9GYSXmrg==",
+          "dev": true,
+          "requires": {
+            "jest-config": "21.2.1",
+            "jest-docblock": "21.2.0",
+            "jest-haste-map": "21.2.0",
+            "jest-jasmine2": "21.2.1",
+            "jest-message-util": "21.2.1",
+            "jest-runtime": "21.2.1",
+            "jest-util": "21.2.1",
+            "pify": "3.0.0",
+            "throat": "4.1.0",
+            "worker-farm": "1.6.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
           }
         }
       }
     },
     "@microsoft/gulp-core-build-karma": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-karma/-/gulp-core-build-karma-4.3.6.tgz",
-      "integrity": "sha1-955PYbJEW25XNyT3jSTzxWoJjb0=",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-karma/-/gulp-core-build-karma-4.5.0.tgz",
+      "integrity": "sha1-aOCaWcKfN6/fisMT7PTJJ8IR/Hs=",
       "dev": true,
       "requires": {
-        "@microsoft/gulp-core-build": "3.2.7",
+        "@microsoft/gulp-core-build": "3.7.4",
         "chai": "3.5.0",
         "gulp": "3.9.1",
         "gulp-karma": "0.0.5",
@@ -201,16 +596,130 @@
         "karma-mocha-clean-reporter": "0.0.1",
         "karma-phantomjs-launcher": "1.0.4",
         "karma-sinon-chai": "1.2.4",
-        "karma-webpack": "2.0.13",
+        "karma-webpack": "2.0.9",
         "lolex": "1.4.0",
         "mocha": "3.4.2",
         "phantomjs-polyfill": "0.0.2",
         "phantomjs-prebuilt": "2.1.16",
         "sinon": "1.17.7",
         "sinon-chai": "2.8.0",
-        "webpack": "3.6.0"
+        "webpack": "3.11.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.6.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
+          "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
+          "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
         "sinon": {
           "version": "1.17.7",
           "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
@@ -220,7 +729,7 @@
             "formatio": "1.1.1",
             "lolex": "1.3.2",
             "samsam": "1.1.2",
-            "util": "0.10.3"
+            "util": "0.11.0"
           },
           "dependencies": {
             "lolex": {
@@ -230,18 +739,111 @@
               "dev": true
             }
           }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "webpack": {
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
+          "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.6.2",
+            "acorn-dynamic-import": "2.0.2",
+            "ajv": "6.5.1",
+            "ajv-keywords": "3.2.0",
+            "async": "2.6.0",
+            "enhanced-resolve": "3.4.1",
+            "escope": "3.6.0",
+            "interpret": "1.1.0",
+            "json-loader": "0.5.7",
+            "json5": "0.5.1",
+            "loader-runner": "2.3.0",
+            "loader-utils": "1.1.0",
+            "memory-fs": "0.4.1",
+            "mkdirp": "0.5.1",
+            "node-libs-browser": "2.1.0",
+            "source-map": "0.5.7",
+            "supports-color": "4.5.0",
+            "tapable": "0.2.8",
+            "uglifyjs-webpack-plugin": "0.4.6",
+            "watchpack": "1.6.0",
+            "webpack-sources": "1.1.0",
+            "yargs": "8.0.2"
+          }
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          }
         }
       }
     },
     "@microsoft/gulp-core-build-sass": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-sass/-/gulp-core-build-sass-4.1.14.tgz",
-      "integrity": "sha1-JAd81AVHfhGXYcYpbsfb/83cq4s=",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-sass/-/gulp-core-build-sass-4.3.14.tgz",
+      "integrity": "sha1-ntG0n9eEwkdeb1qOJdzszSBUGiM=",
       "dev": true,
       "requires": {
-        "@microsoft/gulp-core-build": "3.2.7",
-        "@microsoft/load-themed-styles": "1.7.9",
-        "@types/node": "6.0.88",
+        "@microsoft/gulp-core-build": "3.7.4",
+        "@microsoft/load-themed-styles": "1.7.53",
+        "@types/node": "8.5.8",
         "autoprefixer": "6.3.7",
         "gulp": "3.9.1",
         "gulp-clean-css": "3.0.4",
@@ -249,31 +851,34 @@
         "gulp-clone": "1.0.0",
         "gulp-postcss": "6.3.0",
         "gulp-sass": "3.1.0",
+        "gulp-sourcemaps": "2.6.4",
         "gulp-texttojs": "1.0.3",
         "merge2": "1.0.3",
-        "postcss-modules": "0.6.4"
+        "postcss-modules": "0.6.4",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
           "dev": true
         }
       }
     },
     "@microsoft/gulp-core-build-serve": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-serve/-/gulp-core-build-serve-3.1.14.tgz",
-      "integrity": "sha1-M7Hz7idCSNJO7ZxcxJ9gc7YmszI=",
+      "version": "3.2.26",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-serve/-/gulp-core-build-serve-3.2.26.tgz",
+      "integrity": "sha1-pEJUtTek1SMWnXU4fMzJaMgEz9s=",
       "dev": true,
       "requires": {
-        "@microsoft/gulp-core-build": "3.2.7",
-        "@types/node": "6.0.88",
-        "deasync": "0.1.12",
-        "express": "4.14.1",
+        "@microsoft/gulp-core-build": "3.7.4",
+        "@types/node": "8.5.8",
+        "colors": "1.2.5",
+        "deasync": "0.1.13",
+        "express": "4.16.3",
         "gulp": "3.9.1",
-        "gulp-connect": "5.0.0",
+        "gulp-connect": "5.5.0",
         "gulp-open": "2.0.0",
         "gulp-util": "3.0.8",
         "node-forge": "0.7.5",
@@ -281,32 +886,33 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
           "dev": true
         }
       }
     },
     "@microsoft/gulp-core-build-typescript": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-4.2.14.tgz",
-      "integrity": "sha1-YIseBrJ4Kmz9XiOh6me51iAgAWE=",
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-4.9.7.tgz",
+      "integrity": "sha1-onPAdy4ppHoTA7zwpVj5O6ywXJc=",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor": "4.2.6",
-        "@microsoft/gulp-core-build": "3.2.7",
-        "@microsoft/node-core-library": "0.3.16",
-        "@types/fs-extra": "0.0.37",
+        "@microsoft/api-extractor": "5.6.5",
+        "@microsoft/gulp-core-build": "3.7.4",
+        "@microsoft/node-core-library": "1.2.0",
+        "@types/fs-extra": "5.0.1",
         "@types/gulp": "3.8.32",
-        "@types/node": "6.0.88",
-        "fs-extra": "0.26.7",
+        "@types/node": "8.5.8",
+        "@types/vinyl": "1.2.30",
+        "fs-extra": "5.0.0",
         "gulp": "3.9.1",
         "gulp-cache": "0.4.6",
         "gulp-changed": "1.3.2",
         "gulp-decomment": "0.1.3",
         "gulp-plumber": "1.1.0",
-        "gulp-sourcemaps": "1.6.0",
+        "gulp-sourcemaps": "2.6.4",
         "gulp-texttojs": "1.0.3",
         "gulp-typescript": "3.1.7",
         "gulp-util": "3.0.8",
@@ -315,16 +921,45 @@
         "merge2": "1.0.3",
         "object-assign": "4.1.1",
         "through2": "2.0.3",
-        "tslint": "5.6.0",
+        "tslint": "5.9.1",
         "tslint-microsoft-contrib": "5.0.3",
         "typescript": "2.4.2"
       },
       "dependencies": {
+        "@types/fs-extra": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
+          "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "8.5.8"
+          }
+        },
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
           "dev": true
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
         },
         "lodash": {
           "version": "4.15.0",
@@ -335,45 +970,259 @@
       }
     },
     "@microsoft/gulp-core-build-webpack": {
-      "version": "3.2.14",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-webpack/-/gulp-core-build-webpack-3.2.14.tgz",
-      "integrity": "sha1-KeT5vNGtHtT+1b3XgqtD/J5txDY=",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-webpack/-/gulp-core-build-webpack-3.4.0.tgz",
+      "integrity": "sha1-h7SQWxMbJ+5K/3EyDLfsSLueFco=",
       "dev": true,
       "requires": {
-        "@microsoft/gulp-core-build": "3.2.7",
+        "@microsoft/gulp-core-build": "3.7.4",
         "@types/gulp": "3.8.32",
-        "@types/node": "6.0.88",
+        "@types/node": "8.5.8",
+        "colors": "1.2.5",
         "gulp": "3.9.1",
         "gulp-util": "3.0.8",
-        "webpack": "3.6.0"
+        "webpack": "3.11.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
           "dev": true
+        },
+        "acorn": {
+          "version": "5.6.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
+          "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
+          "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "webpack": {
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
+          "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.6.2",
+            "acorn-dynamic-import": "2.0.2",
+            "ajv": "6.5.1",
+            "ajv-keywords": "3.2.0",
+            "async": "2.6.0",
+            "enhanced-resolve": "3.4.1",
+            "escope": "3.6.0",
+            "interpret": "1.1.0",
+            "json-loader": "0.5.7",
+            "json5": "0.5.1",
+            "loader-runner": "2.3.0",
+            "loader-utils": "1.1.0",
+            "memory-fs": "0.4.1",
+            "mkdirp": "0.5.1",
+            "node-libs-browser": "2.1.0",
+            "source-map": "0.5.7",
+            "supports-color": "4.5.0",
+            "tapable": "0.2.8",
+            "uglifyjs-webpack-plugin": "0.4.6",
+            "watchpack": "1.6.0",
+            "webpack-sources": "1.1.0",
+            "yargs": "8.0.2"
+          }
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          }
         }
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.9.tgz",
-      "integrity": "sha1-ge9rX6BqbyAb+turkx/VKUO2QBM="
+      "version": "1.7.53",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.53.tgz",
+      "integrity": "sha1-J7KoW8wJdoyOwrZS/9mIBCeah8U="
     },
     "@microsoft/loader-cased-file": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/loader-cased-file/-/loader-cased-file-1.4.1.tgz",
-      "integrity": "sha1-46MfRZPjDeI8kaYACDvGtrpte2I=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/loader-cased-file/-/loader-cased-file-1.5.0.tgz",
+      "integrity": "sha1-vjpusAwWh4O1j+slfybFS6MeYsg=",
       "dev": true,
       "requires": {
         "@types/lodash": "4.14.74",
-        "@types/node": "6.0.64",
+        "@types/node": "8.5.8",
         "file-loader": "1.1.11",
         "loader-utils": "1.1.0",
         "lodash": "4.15.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+          "dev": true
+        },
         "lodash": {
           "version": "4.15.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
@@ -383,12 +1232,12 @@
       }
     },
     "@microsoft/loader-load-themed-styles": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.6.4.tgz",
-      "integrity": "sha1-9FItWFxDhxESO3uYY1YVPjkdmy8=",
+      "version": "1.7.35",
+      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.35.tgz",
+      "integrity": "sha1-AS86Xqcc8B0LdgVB57zlVy29dbE=",
       "dev": true,
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.9",
+        "@microsoft/load-themed-styles": "1.7.53",
         "loader-utils": "1.1.0"
       }
     },
@@ -399,17 +1248,17 @@
       "dev": true,
       "requires": {
         "es6-promise": "4.1.1",
-        "superagent": "3.8.2"
+        "superagent": "3.8.3"
       }
     },
     "@microsoft/node-core-library": {
-      "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-0.3.16.tgz",
-      "integrity": "sha1-zvPzDA/N2fGvIItc6hXCLzd+d0U=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-1.2.0.tgz",
+      "integrity": "sha1-mKf9xDdjnpWVjJ3AsXGOuxl+xvM=",
       "dev": true,
       "requires": {
         "@types/fs-extra": "0.0.37",
-        "@types/node": "6.0.88",
+        "@types/node": "8.5.8",
         "@types/z-schema": "3.16.31",
         "fs-extra": "0.26.7",
         "jju": "1.3.0",
@@ -417,83 +1266,76 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
           "dev": true
         }
       }
     },
     "@microsoft/office-ui-fabric-react-bundle": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.4.1.tgz",
-      "integrity": "sha1-aJHrZmclJbmIHwdOR+ggCcCJ4b4=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.5.0.tgz",
+      "integrity": "sha1-57k+n8ChbD0f/zOJYAU4Knoc4c4=",
       "requires": {
         "@types/react": "15.6.6",
         "@types/webpack-env": "1.13.1",
-        "@uifabric/icons": "5.2.0",
-        "office-ui-fabric-react": "5.21.0",
+        "@uifabric/icons": "5.7.1",
+        "office-ui-fabric-react": "5.83.0",
         "react": "15.6.2",
         "react-dom": "15.6.2",
         "tslib": "1.8.1"
-      },
-      "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q=="
-        }
       }
     },
     "@microsoft/package-deps-hash": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/package-deps-hash/-/package-deps-hash-2.1.4.tgz",
-      "integrity": "sha1-wn9LQVQwI0+MkAGoTMZnZ6G/s6w=",
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/@microsoft/package-deps-hash/-/package-deps-hash-2.2.34.tgz",
+      "integrity": "sha1-47M/8HyMepp7YDxuzcRfksWRf8s=",
       "dev": true
     },
     "@microsoft/rush-lib": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/rush-lib/-/rush-lib-4.0.1.tgz",
-      "integrity": "sha1-IuxGbBKU4yzjOPb31QQaQWJ4B5A=",
+      "version": "5.0.0-dev.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/rush-lib/-/rush-lib-5.0.0-dev.8.tgz",
+      "integrity": "sha1-nBoOoHSK4KRa2peQEWH1Lxtk/4A=",
       "dev": true,
       "requires": {
-        "@microsoft/node-core-library": "0.3.16",
-        "@microsoft/package-deps-hash": "2.1.4",
-        "@microsoft/stream-collator": "2.1.4",
-        "@microsoft/ts-command-line": "2.2.4",
-        "@types/fs-extra": "0.0.37",
-        "@types/node": "6.0.88",
-        "@types/z-schema": "3.16.31",
+        "@microsoft/node-core-library": "1.2.0",
+        "@microsoft/package-deps-hash": "2.2.34",
+        "@microsoft/stream-collator": "2.2.34",
+        "@microsoft/ts-command-line": "4.0.0",
+        "@pnpm/link-bins": "1.0.3",
+        "@pnpm/logger": "1.0.2",
         "builtins": "1.0.3",
-        "colors": "1.1.2",
-        "fs-extra": "0.26.7",
+        "colors": "1.2.5",
+        "fs-extra": "5.0.0",
         "git-repo-info": "1.1.4",
         "glob": "7.0.6",
         "glob-escape": "0.0.2",
         "inquirer": "1.2.3",
         "jju": "1.3.0",
+        "js-yaml": "3.9.1",
         "lodash": "4.15.0",
         "minimatch": "3.0.4",
         "npm-package-arg": "5.1.2",
         "read-package-tree": "5.1.6",
         "rimraf": "2.5.4",
         "semver": "5.3.0",
-        "tar": "3.1.15",
+        "strict-uri-encode": "2.0.0",
+        "tar": "4.4.4",
         "wordwrap": "1.0.0",
         "z-schema": "3.18.4"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
-          "dev": true
-        },
-        "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-          "dev": true
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
         },
         "glob": {
           "version": "7.0.6",
@@ -509,21 +1351,49 @@
             "path-is-absolute": "1.0.1"
           }
         },
+        "js-yaml": {
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+          "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
         "lodash": {
           "version": "4.15.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
           "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk=",
           "dev": true
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
         "tar": {
-          "version": "3.1.15",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-3.1.15.tgz",
-          "integrity": "sha512-pQNFsg+Wb6VXsrIPUnuQwrHR4wD5ASBR0jRyiT4/AALFA2Nl+CjhkDX5fTmIwCuULRtyQR3Dae2BBnP2EFHscw==",
+          "version": "4.4.4",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.4.tgz",
+          "integrity": "sha512-mq9ixIYfNF9SK0IS/h2HKMu8Q2iaCuhDDsZhdEag/FHv8fOaYld4vN7ouMgcSSt5WKZzPs8atclTcJm36OTh4w==",
           "dev": true,
           "requires": {
-            "minipass": "2.2.4",
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.3",
             "minizlib": "1.1.0",
             "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
             "yallist": "3.0.2"
           }
         },
@@ -532,20 +1402,46 @@
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "dev": true
         }
       }
     },
     "@microsoft/set-webpack-public-path-plugin": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/set-webpack-public-path-plugin/-/set-webpack-public-path-plugin-1.3.4.tgz",
-      "integrity": "sha1-YRl8XPHZEqzT0w2BxrpEWKJ0ihg=",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/set-webpack-public-path-plugin/-/set-webpack-public-path-plugin-1.5.5.tgz",
+      "integrity": "sha1-51yhMl0a5YAQlda7wP4JvX68Erg=",
       "dev": true,
       "requires": {
-        "@types/webpack": "3.0.11",
+        "@types/node": "8.5.8",
+        "@types/tapable": "0.2.4",
+        "@types/webpack": "3.8.11",
         "lodash": "4.15.0",
         "uglify-js": "3.0.28"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+          "dev": true
+        },
+        "@types/webpack": {
+          "version": "3.8.11",
+          "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-3.8.11.tgz",
+          "integrity": "sha512-6a+XQjFMAJekCE7IxkDavoX8cGCEmTE+MrKeUK4CL0Q7SL9w4c5TdrYrUEzcJx3GX3I0fTIC79x0C07Pi5VmlA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "8.5.8",
+            "@types/tapable": "0.2.4",
+            "@types/uglify-js": "3.0.2",
+            "source-map": "0.6.1"
+          }
+        },
         "commander": {
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
@@ -558,6 +1454,12 @@
           "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk=",
           "dev": true
         },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
         "uglify-js": {
           "version": "3.0.28",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.28.tgz",
@@ -566,52 +1468,54 @@
           "requires": {
             "commander": "2.11.0",
             "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
           }
         }
       }
     },
     "@microsoft/sp-application-base": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-application-base/-/sp-application-base-1.4.1.tgz",
-      "integrity": "sha1-ThVXpNLQyEVTbDadXBjbDhZWr50=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-application-base/-/sp-application-base-1.5.0.tgz",
+      "integrity": "sha1-+33k2VtwZBsuvHZ44iYX2q+U2BU=",
       "dev": true,
       "requires": {
-        "@microsoft/decorators": "1.4.1",
-        "@microsoft/load-themed-styles": "1.7.9",
-        "@microsoft/sp-component-base": "1.4.1",
-        "@microsoft/sp-core-library": "1.4.1",
-        "@microsoft/sp-extension-base": "1.4.1",
-        "@microsoft/sp-http": "1.4.1",
-        "@microsoft/sp-loader": "1.4.1",
-        "@microsoft/sp-lodash-subset": "1.4.1",
-        "@microsoft/sp-module-interfaces": "1.4.1",
-        "@microsoft/sp-odata-types": "1.4.1",
-        "@microsoft/sp-page-context": "1.4.1",
+        "@microsoft/decorators": "1.5.0",
+        "@microsoft/load-themed-styles": "1.7.53",
+        "@microsoft/sp-component-base": "1.5.0",
+        "@microsoft/sp-core-library": "1.5.0",
+        "@microsoft/sp-diagnostics": "1.5.0",
+        "@microsoft/sp-extension-base": "1.5.0",
+        "@microsoft/sp-http": "1.5.0",
+        "@microsoft/sp-loader": "1.5.0",
+        "@microsoft/sp-lodash-subset": "1.5.0",
+        "@microsoft/sp-module-interfaces": "1.5.0",
+        "@microsoft/sp-odata-types": "1.5.0",
+        "@microsoft/sp-page-context": "1.5.0",
         "@types/es6-promise": "0.0.33",
         "@types/webpack-env": "1.13.1",
         "tslib": "1.8.1"
-      },
-      "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q==",
-          "dev": true
-        }
       }
     },
     "@microsoft/sp-build-common": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-common/-/sp-build-common-1.4.1.tgz",
-      "integrity": "sha1-fP9qvOojT2oTxLrLFxlbD1cR1wY=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-common/-/sp-build-common-1.5.0.tgz",
+      "integrity": "sha1-E2lNhHTGVg1DfzzxruQ+ZyaqR9U=",
       "dev": true,
       "requires": {
-        "@microsoft/gulp-core-build": "3.2.7",
-        "@microsoft/gulp-core-build-typescript": "4.2.14",
-        "@microsoft/sp-tslint-rules": "1.4.1",
+        "@microsoft/gulp-core-build": "3.7.4",
+        "@microsoft/gulp-core-build-typescript": "4.9.7",
+        "@microsoft/sp-tslint-rules": "1.5.0",
         "@types/yargs": "0.0.35",
         "gulp": "3.9.1",
         "jju": "1.3.0",
+        "typescript": "2.4.2",
         "yargs": "4.6.0"
       },
       "dependencies": {
@@ -624,40 +1528,39 @@
       }
     },
     "@microsoft/sp-build-core-tasks": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-core-tasks/-/sp-build-core-tasks-1.4.1.tgz",
-      "integrity": "sha1-ERMUj1CwRvEsX6OenM4uyJe9Lo4=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-core-tasks/-/sp-build-core-tasks-1.5.0.tgz",
+      "integrity": "sha1-jscKiVBtE/TQIj9blEM7mOu0UDM=",
       "dev": true,
       "requires": {
-        "@microsoft/gulp-core-build": "3.2.7",
-        "@microsoft/gulp-core-build-karma": "4.3.6",
-        "@microsoft/gulp-core-build-serve": "3.1.14",
-        "@microsoft/gulp-core-build-webpack": "3.2.14",
-        "@microsoft/load-themed-styles": "1.7.9",
-        "@microsoft/loader-cased-file": "1.4.1",
-        "@microsoft/loader-load-themed-styles": "1.6.4",
-        "@microsoft/node-core-library": "0.3.16",
-        "@microsoft/rush-lib": "4.0.1",
-        "@microsoft/set-webpack-public-path-plugin": "1.3.4",
-        "@microsoft/sp-module-interfaces": "1.4.1",
-        "@microsoft/sp-polyfills": "1.2.0",
-        "@types/colors": "1.1.1",
-        "@types/es6-promise": "0.0.33",
+        "@microsoft/gulp-core-build": "3.7.4",
+        "@microsoft/gulp-core-build-karma": "4.5.0",
+        "@microsoft/gulp-core-build-serve": "3.2.26",
+        "@microsoft/gulp-core-build-webpack": "3.4.0",
+        "@microsoft/load-themed-styles": "1.7.53",
+        "@microsoft/loader-cased-file": "1.5.0",
+        "@microsoft/loader-load-themed-styles": "1.7.35",
+        "@microsoft/node-core-library": "1.2.0",
+        "@microsoft/rush-lib": "5.0.0-dev.8",
+        "@microsoft/set-webpack-public-path-plugin": "1.5.5",
+        "@microsoft/sp-module-interfaces": "1.5.0",
+        "@microsoft/sp-polyfills": "1.4.0",
         "@types/finalhandler": "0.0.31",
         "@types/fs-extra": "0.0.37",
         "@types/glob": "5.0.30",
         "@types/gulp-replace": "0.0.29",
         "@types/lodash": "4.14.74",
         "@types/merge2": "0.3.29",
-        "@types/node": "6.0.64",
+        "@types/node": "8.5.8",
         "@types/resolve": "0.0.4",
         "@types/rimraf": "0.0.28",
         "@types/serve-static": "1.7.31",
+        "@types/tapable": "0.2.4",
         "@types/uuid": "3.0.0",
         "@types/webpack": "3.0.11",
         "@types/webpack-stream": "3.2.7",
         "azure-storage": "0.10.0",
-        "colors": "1.1.2",
+        "colors": "1.2.5",
         "css-loader": "0.28.11",
         "finalhandler": "0.4.1",
         "fs-extra": "0.26.7",
@@ -668,11 +1571,12 @@
         "gulp-util": "3.0.8",
         "html-loader": "0.5.5",
         "json-loader": "0.5.7",
+        "json-schema": "0.2.3",
         "lodash": "4.15.0",
         "merge2": "1.0.3",
         "node-zip": "1.1.1",
         "phantomjs-prebuilt": "2.1.16",
-        "resolve": "1.1.7",
+        "resolve": "1.7.1",
         "rimraf": "2.6.2",
         "serve-static": "1.10.3",
         "source-map-loader": "0.2.3",
@@ -684,37 +1588,23 @@
       },
       "dependencies": {
         "@microsoft/sp-polyfills": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.2.0.tgz",
-          "integrity": "sha1-w6MYuEq9uEl8jKzi5LPU8hoPAII=",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.4.0.tgz",
+          "integrity": "sha1-RVTJxPw2OlJ2neuEvb9Ju5OTMtA=",
           "dev": true,
           "requires": {
-            "@types/es6-promise": "0.0.32",
-            "@types/webpack-env": "1.13.0",
+            "@types/webpack-env": "1.13.1",
             "es6-collections": "0.5.6",
             "es6-promise": "4.1.1",
+            "tslib": "1.8.1",
             "whatwg-fetch": "2.0.3",
             "whatwg-url": "4.7.1"
-          },
-          "dependencies": {
-            "@types/es6-promise": {
-              "version": "0.0.32",
-              "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
-              "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0=",
-              "dev": true
-            }
           }
         },
-        "@types/webpack-env": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.0.tgz",
-          "integrity": "sha1-MEQ4FkfhHulzxa8uklMjkw9pHYA=",
-          "dev": true
-        },
-        "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
           "dev": true
         },
         "debug": {
@@ -725,6 +1615,12 @@
           "requires": {
             "ms": "0.7.1"
           }
+        },
+        "etag": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+          "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
+          "dev": true
         },
         "finalhandler": {
           "version": "0.4.1",
@@ -737,6 +1633,12 @@
             "on-finished": "2.3.0",
             "unpipe": "1.0.0"
           }
+        },
+        "fresh": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+          "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
+          "dev": true
         },
         "glob": {
           "version": "7.0.6",
@@ -784,12 +1686,6 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
           "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU=",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         },
         "rimraf": {
@@ -853,21 +1749,22 @@
       }
     },
     "@microsoft/sp-build-web": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-web/-/sp-build-web-1.4.1.tgz",
-      "integrity": "sha1-hVxTq0VbcsnGIgh84/T2X9uaHb4=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-web/-/sp-build-web-1.5.0.tgz",
+      "integrity": "sha1-wmkiu4CT5vdAw8cwJyXyr2Cq45w=",
       "dev": true,
       "requires": {
-        "@microsoft/gulp-core-build": "3.2.7",
-        "@microsoft/gulp-core-build-karma": "4.3.6",
-        "@microsoft/gulp-core-build-sass": "4.1.14",
-        "@microsoft/gulp-core-build-serve": "3.1.14",
-        "@microsoft/gulp-core-build-typescript": "4.2.14",
-        "@microsoft/gulp-core-build-webpack": "3.2.14",
-        "@microsoft/sp-build-common": "1.4.1",
-        "@microsoft/sp-build-core-tasks": "1.4.1",
-        "@microsoft/sp-polyfills": "1.4.1",
+        "@microsoft/gulp-core-build": "3.7.4",
+        "@microsoft/gulp-core-build-karma": "4.5.0",
+        "@microsoft/gulp-core-build-sass": "4.3.14",
+        "@microsoft/gulp-core-build-serve": "3.2.26",
+        "@microsoft/gulp-core-build-typescript": "4.9.7",
+        "@microsoft/gulp-core-build-webpack": "3.4.0",
+        "@microsoft/sp-build-common": "1.5.0",
+        "@microsoft/sp-build-core-tasks": "1.5.0",
+        "@microsoft/sp-polyfills": "1.5.0",
         "@types/karma": "0.13.33",
+        "@types/tapable": "0.2.4",
         "@types/webpack": "3.0.11",
         "gulp": "3.9.1",
         "webpack": "3.6.0",
@@ -875,100 +1772,94 @@
       }
     },
     "@microsoft/sp-client-preview": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-client-preview/-/sp-client-preview-1.4.1.tgz",
-      "integrity": "sha1-QpSjwxDcgF8aOF+6hrO502AFyxg=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-client-preview/-/sp-client-preview-1.5.0.tgz",
+      "integrity": "sha1-WnFLxZFZ310U7V1kmeMwbP4oc4M=",
       "dev": true,
       "requires": {
         "@microsoft/microsoft-graph-client": "1.0.0",
-        "@microsoft/sp-core-library": "1.4.1",
-        "@microsoft/sp-http": "1.4.1",
-        "@microsoft/sp-lodash-subset": "1.4.1",
+        "@microsoft/sp-core-library": "1.5.0",
+        "@microsoft/sp-http": "1.5.0",
+        "@microsoft/sp-lodash-subset": "1.5.0",
         "@types/webpack-env": "1.13.1",
         "tslib": "1.8.1"
-      },
-      "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q==",
-          "dev": true
-        }
       }
     },
     "@microsoft/sp-component-base": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.4.1.tgz",
-      "integrity": "sha1-XATqwkm39UEWrh7DPWTqq9eI/J8=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.5.0.tgz",
+      "integrity": "sha1-YSKUGmcLsJX+jHK2J/L5DbpeyEY=",
       "requires": {
-        "@microsoft/decorators": "1.4.1",
-        "@microsoft/sp-core-library": "1.4.1",
-        "@microsoft/sp-loader": "1.4.1",
-        "@microsoft/sp-lodash-subset": "1.4.1",
-        "@microsoft/sp-module-interfaces": "1.4.1",
-        "@microsoft/sp-page-context": "1.4.1",
+        "@microsoft/decorators": "1.5.0",
+        "@microsoft/sp-core-library": "1.5.0",
+        "@microsoft/sp-diagnostics": "1.5.0",
+        "@microsoft/sp-dynamic-data": "1.5.0",
+        "@microsoft/sp-loader": "1.5.0",
+        "@microsoft/sp-lodash-subset": "1.5.0",
+        "@microsoft/sp-module-interfaces": "1.5.0",
+        "@microsoft/sp-page-context": "1.5.0",
+        "@types/es6-promise": "0.0.33",
         "@types/webpack-env": "1.13.1"
-      },
-      "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q=="
-        }
       }
     },
     "@microsoft/sp-core-library": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.4.1.tgz",
-      "integrity": "sha1-sXNOYBUQxwnX2Bh8kjNZIiy10j0=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.5.0.tgz",
+      "integrity": "sha1-ErI/ljtQ6JsY9G+cALg4XCjusTU=",
       "requires": {
-        "@microsoft/sp-lodash-subset": "1.4.1",
-        "@microsoft/sp-module-interfaces": "1.4.1",
+        "@microsoft/sp-lodash-subset": "1.5.0",
+        "@microsoft/sp-module-interfaces": "1.5.0",
         "@types/es6-promise": "0.0.33",
         "@types/webpack-env": "1.13.1"
-      },
-      "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q=="
-        }
+      }
+    },
+    "@microsoft/sp-diagnostics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.5.0.tgz",
+      "integrity": "sha1-6mBvo1p9Tt0cQX6zPwD/Oq8AWac=",
+      "requires": {
+        "@microsoft/sp-core-library": "1.5.0",
+        "@microsoft/sp-lodash-subset": "1.5.0"
+      }
+    },
+    "@microsoft/sp-dynamic-data": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.5.0.tgz",
+      "integrity": "sha1-QONxje3rwt5JC1bCJZ6t7VN7jEc=",
+      "requires": {
+        "@microsoft/sp-core-library": "1.5.0",
+        "@types/webpack-env": "1.13.1",
+        "tslib": "1.8.1"
       }
     },
     "@microsoft/sp-extension-base": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-extension-base/-/sp-extension-base-1.4.1.tgz",
-      "integrity": "sha1-lsBYABoaim9jPB8UWCJfbZGZnO0=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-extension-base/-/sp-extension-base-1.5.0.tgz",
+      "integrity": "sha1-/MBNrjp6virdKYX22g9oL7GtgNE=",
       "dev": true,
       "requires": {
-        "@microsoft/decorators": "1.4.1",
-        "@microsoft/sp-component-base": "1.4.1",
-        "@microsoft/sp-core-library": "1.4.1",
-        "@microsoft/sp-http": "1.4.1",
-        "@microsoft/sp-loader": "1.4.1",
-        "@microsoft/sp-lodash-subset": "1.4.1",
-        "@microsoft/sp-module-interfaces": "1.4.1",
-        "@microsoft/sp-page-context": "1.4.1",
+        "@microsoft/decorators": "1.5.0",
+        "@microsoft/sp-component-base": "1.5.0",
+        "@microsoft/sp-core-library": "1.5.0",
+        "@microsoft/sp-diagnostics": "1.5.0",
+        "@microsoft/sp-http": "1.5.0",
+        "@microsoft/sp-loader": "1.5.0",
+        "@microsoft/sp-lodash-subset": "1.5.0",
+        "@microsoft/sp-module-interfaces": "1.5.0",
+        "@microsoft/sp-page-context": "1.5.0",
         "@types/es6-promise": "0.0.33",
         "@types/webpack-env": "1.13.1"
-      },
-      "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q==",
-          "dev": true
-        }
       }
     },
     "@microsoft/sp-http": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.4.1.tgz",
-      "integrity": "sha1-ha4z7IM3ZEAmdBqc5H0imWRdv10=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.5.0.tgz",
+      "integrity": "sha1-IDZQfy10P3GsjinEN0nRUsDmxfE=",
       "requires": {
-        "@microsoft/decorators": "1.4.1",
-        "@microsoft/sp-core-library": "1.4.1",
-        "@microsoft/sp-lodash-subset": "1.4.1",
+        "@microsoft/decorators": "1.5.0",
+        "@microsoft/sp-core-library": "1.5.0",
+        "@microsoft/sp-diagnostics": "1.5.0",
+        "@microsoft/sp-lodash-subset": "1.5.0",
         "@types/adal": "1.0.27",
         "@types/es6-promise": "0.0.33",
         "@types/sinon": "1.16.34",
@@ -981,120 +1872,118 @@
           "version": "1.16.34",
           "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-1.16.34.tgz",
           "integrity": "sha1-qXYf/zPQ97P+YYdbV3d4oldqmgM="
-        },
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q=="
         }
       }
     },
     "@microsoft/sp-loader": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.4.1.tgz",
-      "integrity": "sha1-W3jbTZZ8zuXJIrWLSKnW4NlEE6o=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.5.0.tgz",
+      "integrity": "sha1-WamkA2bkJB3QuOTPV4EOkKwwHHU=",
       "requires": {
-        "@microsoft/office-ui-fabric-react-bundle": "1.4.1",
-        "@microsoft/sp-core-library": "1.4.1",
-        "@microsoft/sp-lodash-subset": "1.4.1",
-        "@microsoft/sp-module-interfaces": "1.4.1",
-        "@microsoft/sp-odata-types": "1.4.1",
-        "@microsoft/sp-polyfills": "1.4.1",
+        "@microsoft/office-ui-fabric-react-bundle": "1.5.0",
+        "@microsoft/sp-core-library": "1.5.0",
+        "@microsoft/sp-diagnostics": "1.5.0",
+        "@microsoft/sp-dynamic-data": "1.5.0",
+        "@microsoft/sp-http": "1.5.0",
+        "@microsoft/sp-lodash-subset": "1.5.0",
+        "@microsoft/sp-module-interfaces": "1.5.0",
+        "@microsoft/sp-odata-types": "1.5.0",
+        "@microsoft/sp-page-context": "1.5.0",
+        "@microsoft/sp-polyfills": "1.5.0",
         "@types/es6-promise": "0.0.33",
+        "@types/node": "8.5.8",
         "@types/react": "15.6.6",
         "@types/react-dom": "15.5.6",
         "@types/requirejs": "2.1.29",
         "@types/webpack-env": "1.13.1",
-        "office-ui-fabric-react": "5.21.0",
+        "@uifabric/utilities": "5.27.0",
+        "office-ui-fabric-react": "5.83.0",
         "react": "15.6.2",
         "react-dom": "15.6.2",
         "requirejs": "2.1.20"
       },
       "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q=="
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg=="
+        },
+        "@uifabric/utilities": {
+          "version": "5.27.0",
+          "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.27.0.tgz",
+          "integrity": "sha512-O2gTEiiGbaqeLZQT5FIYVk2KTMLjKAAgZja866o1hYB5FniTuphjj8UNNSV8IRVdIlVIZ1dLwf9DWv2UCvgT6Q==",
+          "requires": {
+            "@uifabric/merge-styles": "5.17.1",
+            "prop-types": "15.6.1",
+            "tslib": "1.8.1"
+          }
         }
       }
     },
     "@microsoft/sp-lodash-subset": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.4.1.tgz",
-      "integrity": "sha1-7eiXfG9yLjtldwxbYQW2rM2RojI=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.5.0.tgz",
+      "integrity": "sha1-ncO/OJkRx6Mq9lZ583sx3B2MmoA=",
       "requires": {
         "@types/lodash": "4.14.74",
         "@types/webpack-env": "1.13.1",
         "tslib": "1.8.1"
-      },
-      "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q=="
-        }
       }
     },
     "@microsoft/sp-module-interfaces": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.4.1.tgz",
-      "integrity": "sha1-aZAk3PZQiVKKTCL/cmWQmwdl6UI=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.5.0.tgz",
+      "integrity": "sha1-278I5U06HTdElGyogI91wVmGwfU=",
       "requires": {
-        "@types/node": "6.0.64",
+        "@types/node": "8.5.8",
         "@types/z-schema": "3.16.31",
         "z-schema": "3.18.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg=="
+        }
       }
     },
     "@microsoft/sp-odata-types": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.4.1.tgz",
-      "integrity": "sha1-sfM3Xek0Ic8Joe0pecHUwQiYPaI=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.5.0.tgz",
+      "integrity": "sha1-rXY98nDyf8T/tBwN4QPZLFle9Wk=",
       "requires": {
         "tslib": "1.8.1"
       }
     },
     "@microsoft/sp-office-ui-fabric-core": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-office-ui-fabric-core/-/sp-office-ui-fabric-core-1.4.1.tgz",
-      "integrity": "sha1-sTXjdC/q8cpkvB5n9PoXsC+b9MM=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-office-ui-fabric-core/-/sp-office-ui-fabric-core-1.5.0.tgz",
+      "integrity": "sha1-Cu5fXXu3mcKYkxHN0Gfkkdllq2I=",
       "requires": {
         "@types/webpack-env": "1.13.1",
         "office-ui-fabric-core": "9.1.0",
         "tslib": "1.8.1"
-      },
-      "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q=="
-        }
       }
     },
     "@microsoft/sp-page-context": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.4.1.tgz",
-      "integrity": "sha1-zUzO7WKjbWN40rwh6UTSHMs3AMk=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.5.0.tgz",
+      "integrity": "sha1-f1CS+3oTp9Vu2wgTFEydeOYmAKc=",
       "requires": {
-        "@microsoft/sp-core-library": "1.4.1",
-        "@microsoft/sp-http": "1.4.1",
-        "@microsoft/sp-lodash-subset": "1.4.1",
-        "@microsoft/sp-odata-types": "1.4.1",
+        "@microsoft/sp-core-library": "1.5.0",
+        "@microsoft/sp-diagnostics": "1.5.0",
+        "@microsoft/sp-dynamic-data": "1.5.0",
+        "@microsoft/sp-lodash-subset": "1.5.0",
+        "@microsoft/sp-odata-types": "1.5.0",
         "@types/es6-promise": "0.0.33",
         "@types/webpack-env": "1.13.1",
         "tslib": "1.8.1"
-      },
-      "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q=="
-        }
       }
     },
     "@microsoft/sp-polyfills": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.4.1.tgz",
-      "integrity": "sha1-6nm5xsfZa6JwrNy114GY4aqTMt0=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.5.0.tgz",
+      "integrity": "sha1-o20QrAb9SD5dG172pjKCc/Asb0o=",
       "requires": {
         "@types/webpack-env": "1.13.1",
         "es6-collections": "0.5.6",
@@ -1104,11 +1993,6 @@
         "whatwg-url": "4.7.1"
       },
       "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q=="
-        },
         "whatwg-fetch": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
@@ -1117,18 +2001,36 @@
       }
     },
     "@microsoft/sp-tslint-rules": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-tslint-rules/-/sp-tslint-rules-1.4.1.tgz",
-      "integrity": "sha1-/N20u2SBjn5me3rhgXSAdPmR4dA=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-tslint-rules/-/sp-tslint-rules-1.5.0.tgz",
+      "integrity": "sha1-eLPbujRmxioa4zZtEV+3LzzrtgI=",
       "dev": true,
       "requires": {
-        "@microsoft/gulp-core-build": "3.2.7",
-        "@microsoft/gulp-core-build-typescript": "4.2.14",
+        "@microsoft/gulp-core-build": "3.7.4",
+        "@microsoft/gulp-core-build-typescript": "4.9.7",
         "tslint": "5.6.0",
         "tslint-microsoft-contrib": "5.0.3",
         "tsutils": "2.11.2"
       },
       "dependencies": {
+        "tslint": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.6.0.tgz",
+          "integrity": "sha1-CIqmxgJmIzOGULKQCCirPt9Z9s8=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "colors": "1.2.5",
+            "commander": "2.15.1",
+            "diff": "3.5.0",
+            "glob": "7.1.2",
+            "minimatch": "3.0.4",
+            "resolve": "1.7.1",
+            "semver": "5.3.0",
+            "tslib": "1.8.1",
+            "tsutils": "2.11.2"
+          }
+        },
         "tsutils": {
           "version": "2.11.2",
           "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.11.2.tgz",
@@ -1141,134 +2043,120 @@
       }
     },
     "@microsoft/sp-webpart-base": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.4.1.tgz",
-      "integrity": "sha1-sODXFFiT7bJXFkBzpV78OnYiZ6k=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.5.0.tgz",
+      "integrity": "sha1-79V9j/3ZIXhymfMetcUor+4am5s=",
       "requires": {
-        "@microsoft/decorators": "1.4.1",
-        "@microsoft/load-themed-styles": "1.7.9",
-        "@microsoft/office-ui-fabric-react-bundle": "1.4.1",
-        "@microsoft/sp-component-base": "1.4.1",
-        "@microsoft/sp-core-library": "1.4.1",
-        "@microsoft/sp-http": "1.4.1",
-        "@microsoft/sp-loader": "1.4.1",
-        "@microsoft/sp-lodash-subset": "1.4.1",
-        "@microsoft/sp-module-interfaces": "1.4.1",
-        "@microsoft/sp-page-context": "1.4.1",
+        "@microsoft/decorators": "1.5.0",
+        "@microsoft/load-themed-styles": "1.7.53",
+        "@microsoft/office-ui-fabric-react-bundle": "1.5.0",
+        "@microsoft/sp-component-base": "1.5.0",
+        "@microsoft/sp-core-library": "1.5.0",
+        "@microsoft/sp-diagnostics": "1.5.0",
+        "@microsoft/sp-dynamic-data": "1.5.0",
+        "@microsoft/sp-http": "1.5.0",
+        "@microsoft/sp-loader": "1.5.0",
+        "@microsoft/sp-lodash-subset": "1.5.0",
+        "@microsoft/sp-module-interfaces": "1.5.0",
+        "@microsoft/sp-page-context": "1.5.0",
         "@types/es6-promise": "0.0.33",
         "@types/react": "15.6.6",
         "@types/react-dom": "15.5.6",
-        "@types/scrollreveal": "0.0.2",
         "@types/webpack-env": "1.13.1",
         "office-ui-fabric": "2.6.1",
-        "office-ui-fabric-react": "5.21.0",
+        "office-ui-fabric-react": "5.83.0",
         "react": "15.6.2",
         "react-dom": "15.6.2",
-        "scrollreveal": "3.3.6",
         "tslib": "1.8.1"
-      },
-      "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q=="
-        }
       }
     },
     "@microsoft/sp-webpart-workbench": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-workbench/-/sp-webpart-workbench-1.4.1.tgz",
-      "integrity": "sha1-v1AFcNFagLOhfXo3Ai8u3FnMUaE=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-workbench/-/sp-webpart-workbench-1.5.0.tgz",
+      "integrity": "sha1-asOTkhrolVHdQCnD9fAClKs2fDU=",
       "dev": true,
       "requires": {
-        "@microsoft/gulp-core-build-serve": "3.1.14",
-        "@microsoft/office-ui-fabric-react-bundle": "1.4.1",
-        "@microsoft/sp-application-base": "1.4.1",
-        "@microsoft/sp-build-core-tasks": "1.4.1",
-        "@microsoft/sp-client-preview": "1.4.1",
-        "@microsoft/sp-core-library": "1.4.1",
-        "@microsoft/sp-loader": "1.4.1",
-        "@microsoft/sp-lodash-subset": "1.4.1",
-        "@microsoft/sp-module-interfaces": "1.4.1",
-        "@microsoft/sp-webpart-base": "1.4.1",
+        "@microsoft/gulp-core-build-serve": "3.2.26",
+        "@microsoft/node-core-library": "1.2.0",
+        "@microsoft/office-ui-fabric-react-bundle": "1.5.0",
+        "@microsoft/sp-application-base": "1.5.0",
+        "@microsoft/sp-build-core-tasks": "1.5.0",
+        "@microsoft/sp-client-preview": "1.5.0",
+        "@microsoft/sp-core-library": "1.5.0",
+        "@microsoft/sp-loader": "1.5.0",
+        "@microsoft/sp-lodash-subset": "1.5.0",
+        "@microsoft/sp-module-interfaces": "1.5.0",
+        "@microsoft/sp-webpart-base": "1.5.0",
         "@types/es6-promise": "0.0.33",
         "@types/fs-extra": "0.0.37",
         "@types/react": "15.6.6",
         "@types/react-dom": "15.5.6",
         "@types/webpack-env": "1.13.1",
         "fs-extra": "0.26.7",
-        "office-ui-fabric-react": "5.21.0",
+        "office-ui-fabric-react": "5.83.0",
+        "prop-types": "15.5.7",
         "react": "15.6.2",
         "react-dom": "15.6.2",
         "tslib": "1.8.1"
       },
       "dependencies": {
-        "@types/webpack-env": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
-          "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q==",
-          "dev": true
+        "prop-types": {
+          "version": "15.5.7",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.7.tgz",
+          "integrity": "sha1-IxxPKc3YLjVQEdSIk4bKkFlUTdE=",
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16"
+          }
         }
       }
     },
     "@microsoft/stream-collator": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/stream-collator/-/stream-collator-2.1.4.tgz",
-      "integrity": "sha1-rPHjbsyZCYQ/o7bpBNVD37arlks=",
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/@microsoft/stream-collator/-/stream-collator-2.2.34.tgz",
+      "integrity": "sha1-TsZnXfl/EPkEeT7yIVeyf7uZKLI=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.88",
-        "colors": "1.1.2"
+        "@types/node": "8.5.8",
+        "colors": "1.2.5"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
-          "dev": true
-        },
-        "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
           "dev": true
         }
       }
     },
     "@microsoft/ts-command-line": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-2.2.4.tgz",
-      "integrity": "sha1-yMbdb/zeE0yt0MnVb7sRnB48KUI=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-4.0.0.tgz",
+      "integrity": "sha1-L0X2iLcayhiVq3yjX6f8AZ0coqg=",
       "dev": true,
       "requires": {
         "@types/argparse": "1.0.33",
-        "@types/node": "6.0.88",
+        "@types/node": "8.5.8",
         "argparse": "1.0.10",
-        "colors": "1.1.2"
+        "colors": "1.2.5"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
-          "dev": true
-        },
-        "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
           "dev": true
         }
       }
     },
     "@pnp/common": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@pnp/common/-/common-1.0.4.tgz",
-      "integrity": "sha1-q11woI9c1+Mu/mX6znzGDzgLxDA=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pnp/common/-/common-1.1.1.tgz",
+      "integrity": "sha1-gkwDPKedxH3vjRqdMiRn5v4Azks=",
       "requires": {
-        "@types/adal-angular": "1.0.0",
+        "@types/adal-angular": "1.0.1",
         "adal-angular": "1.0.17",
-        "tslib": "1.9.0"
+        "tslib": "1.9.1"
       },
       "dependencies": {
         "adal-angular": {
@@ -1277,56 +2165,129 @@
           "integrity": "sha1-bpNuDkH5HTsqiOf/ypwvb29WLMQ="
         },
         "tslib": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+          "integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg=="
         }
       }
     },
     "@pnp/logging": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@pnp/logging/-/logging-1.0.4.tgz",
-      "integrity": "sha1-8y66r/VSF0K1J+DzKo+K6JvtEbQ=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pnp/logging/-/logging-1.1.1.tgz",
+      "integrity": "sha1-+bX4RiMw6dIw96IrW5QgSNWQHYw=",
       "requires": {
-        "tslib": "1.9.0"
+        "tslib": "1.9.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+          "integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg=="
         }
       }
     },
     "@pnp/odata": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@pnp/odata/-/odata-1.0.4.tgz",
-      "integrity": "sha1-Be5QerouPn4PDk8uZnrBedthaXw=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pnp/odata/-/odata-1.1.1.tgz",
+      "integrity": "sha1-IKoVLcLEQjPHbcNf28x81AI5uB8=",
       "requires": {
-        "tslib": "1.9.0"
+        "tslib": "1.9.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+          "integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg=="
         }
       }
     },
     "@pnp/sp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@pnp/sp/-/sp-1.0.4.tgz",
-      "integrity": "sha1-3X/BDrJbYaAxPdZLOS2pjcfqsq8=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pnp/sp/-/sp-1.1.1.tgz",
+      "integrity": "sha1-BdMO42AZ/34499/t8EyxQ9ButAY=",
       "requires": {
-        "tslib": "1.9.0"
+        "tslib": "1.9.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+          "integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg=="
         }
       }
+    },
+    "@pnpm/link-bins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/link-bins/-/link-bins-1.0.3.tgz",
+      "integrity": "sha512-thVgwrQ5rMcPYI6a0IPOt2pnlF1n5zX7BN4CrFeBp0/JCGsZAht/VOPv9bD3cZ+j0vDemEwE23BfhOWxmxq2yQ==",
+      "dev": true,
+      "requires": {
+        "@pnpm/package-bins": "1.0.0",
+        "@pnpm/types": "1.7.0",
+        "@types/mz": "0.0.32",
+        "@types/node": "10.3.2",
+        "@types/ramda": "0.25.32",
+        "@zkochan/cmd-shim": "2.2.4",
+        "arr-flatten": "1.1.0",
+        "is-windows": "1.0.2",
+        "mkdirp-promise": "5.0.1",
+        "mz": "2.7.0",
+        "normalize-path": "3.0.0",
+        "p-filter": "1.0.0",
+        "ramda": "0.25.0",
+        "read-package-json": "2.0.13"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.3.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.2.tgz",
+          "integrity": "sha512-9NfEUDp3tgRhmoxzTpTo+lq+KIVFxZahuRX0LHF/9IzKHaWuoWsIrrJ61zw5cnnlGINX8lqJzXYfQTOICS5Q+A==",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        }
+      }
+    },
+    "@pnpm/logger": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/logger/-/logger-1.0.2.tgz",
+      "integrity": "sha512-A8XbJKvdueazvJGPn1qQ9LL6uopV88ebIT+dJKNQ68gT7yfCbtfT8j5ZzdVczmGbkiuBeZ1VckZerkO0tjOXZA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "10.3.2",
+        "bole": "3.0.2",
+        "ndjson": "1.5.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.3.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.2.tgz",
+          "integrity": "sha512-9NfEUDp3tgRhmoxzTpTo+lq+KIVFxZahuRX0LHF/9IzKHaWuoWsIrrJ61zw5cnnlGINX8lqJzXYfQTOICS5Q+A==",
+          "dev": true
+        }
+      }
+    },
+    "@pnpm/package-bins": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/package-bins/-/package-bins-1.0.0.tgz",
+      "integrity": "sha512-ZqVfIXK3r5AsP5VAhPHrhf3isF+T4yEuUpJTF9T03oFTJ9LBnkKvx8F7P7biKEManxSGOkSpNoIBdsura9pY5Q==",
+      "dev": true,
+      "requires": {
+        "@pnpm/types": "1.7.0",
+        "@types/mz": "0.0.32",
+        "mz": "2.7.0",
+        "p-filter": "1.0.0"
+      }
+    },
+    "@pnpm/types": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/types/-/types-1.7.0.tgz",
+      "integrity": "sha512-pn7g4uxcofWTNG/cxmKvkMK2lxr4OUIhrQDrEVYEdVhW0WkWztsHkFrYjFgfNzPbYu3ITlB3T6aSVjCoJQTOlw==",
+      "dev": true
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
@@ -1350,18 +2311,18 @@
       "resolved": "https://registry.npmjs.org/@types/adal/-/adal-1.0.27.tgz",
       "integrity": "sha512-Dll0X5OdCgnqMhp/bH/XSjFpn1putDI9OVlw+LgmxOjZWKUQXOpHkGWbARNReeYBWmaEvWBVWkZG4yhfcCeOZQ==",
       "requires": {
-        "@types/angular": "1.6.43"
+        "@types/angular": "1.6.45"
       }
     },
     "@types/adal-angular": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/adal-angular/-/adal-angular-1.0.0.tgz",
-      "integrity": "sha512-llI47lHZNDhMtnRKTZ8WsTsBGF5vfFsxYiNu2FwKaucs9z/2ZdjuOMSHeZQsE8BUd5Tg/n4dbsdhbMV8inUAgw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/adal-angular/-/adal-angular-1.0.1.tgz",
+      "integrity": "sha512-2sRGxJYrluhvIz8ae98i5k5woe9Fics4dMFHTcNfY2xAkj5QGZor+sfZzlgM58Fpw7Kklau9Gn6OhgJP25dKug=="
     },
     "@types/angular": {
-      "version": "1.6.43",
-      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.43.tgz",
-      "integrity": "sha512-3GrHCRZS62ruJjHMtOx3WYsS0I8i0FRcIqOwqIfWXnlR9g2FebEhUNdMk3LZIvfhZ08xe+S1x2iwP1t9vKCHag=="
+      "version": "1.6.45",
+      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.45.tgz",
+      "integrity": "sha512-eXm3F/z2j8lVq7yBLL2G8QAygzYAboIJbJ46g26t71hgPtlxV9ibEJIBNj4KxCIZf7DcQo/KSnqaQ/0D9Rx2GA=="
     },
     "@types/argparse": {
       "version": "1.0.33",
@@ -1382,9 +2343,9 @@
       "dev": true
     },
     "@types/chai": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
-      "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=",
+      "version": "3.4.34",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.4.34.tgz",
+      "integrity": "sha1-1TNXkoI7sJzd1eOMPSEbcJGDhU0=",
       "dev": true
     },
     "@types/chalk": {
@@ -1397,12 +2358,6 @@
       "version": "0.22.7",
       "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.7.tgz",
       "integrity": "sha512-+T9qBbqe/jXtTjzVddArZExahoPPmt8eq3O1ZuCKZXjBVxf/ciUYNXrIDZJEVgYvpELnv6VlPRCfLzufRxpAag==",
-      "dev": true
-    },
-    "@types/colors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/colors/-/colors-1.1.1.tgz",
-      "integrity": "sha1-SXM5KPtHzxElS3YR4vb4X/YCBSE=",
       "dev": true
     },
     "@types/enzyme": {
@@ -1427,13 +2382,14 @@
       "dev": true
     },
     "@types/express-serve-static-core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.1.tgz",
-      "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz",
+      "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
       "dev": true,
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "6.0.64"
+        "@types/node": "6.0.64",
+        "@types/range-parser": "1.2.2"
       }
     },
     "@types/finalhandler": {
@@ -1549,15 +2505,25 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "2.2.48",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
-      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "version": "2.2.38",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.38.tgz",
+      "integrity": "sha1-jBiPbjTC58Px0BJ9kI1aNuWmDck=",
       "dev": true
+    },
+    "@types/mz": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.32.tgz",
+      "integrity": "sha512-cy3yebKhrHuOcrJGkfwNHhpTXQLgmXSv1BX+4p32j+VUQ6aP2eJ5cL7OvGcAQx75fCTFaAIIAKewvqL+iwSd4g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "6.0.64"
+      }
     },
     "@types/node": {
       "version": "6.0.64",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.64.tgz",
-      "integrity": "sha1-zckBQR9jAeFDff7SO8aPVEQuTcg="
+      "integrity": "sha1-zckBQR9jAeFDff7SO8aPVEQuTcg=",
+      "dev": true
     },
     "@types/node-notifier": {
       "version": "0.0.28",
@@ -1581,6 +2547,18 @@
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
       "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
+      "dev": true
+    },
+    "@types/ramda": {
+      "version": "0.25.32",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.25.32.tgz",
+      "integrity": "sha512-KvkOhOprW8ln1XtlBoUPxrObnrZ1SQZezF9UlkWMYF0ZKpzlbwZDEcMZo6XcMsg/9M9Vl1lstCnCE8J7qxFAvQ==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.2.tgz",
+      "integrity": "sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw==",
       "dev": true
     },
     "@types/react": {
@@ -1616,11 +2594,6 @@
       "integrity": "sha1-VWJRm8eWPKyoq/fxKMrjtZTUHQY=",
       "dev": true
     },
-    "@types/scrollreveal": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@types/scrollreveal/-/scrollreveal-0.0.2.tgz",
-      "integrity": "sha1-erQNpSRC0dTkF1N/cO9afuXiutk="
-    },
     "@types/semver": {
       "version": "5.3.33",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.3.33.tgz",
@@ -1633,7 +2606,7 @@
       "integrity": "sha1-FUVt6NmNa0z/Mb5savdJKuY/Uho=",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.11.1",
+        "@types/express-serve-static-core": "4.16.0",
         "@types/mime": "2.0.0"
       }
     },
@@ -1644,9 +2617,9 @@
       "dev": true
     },
     "@types/tapable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.2.tgz",
-      "integrity": "sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-0.2.4.tgz",
+      "integrity": "sha512-pclMAvhPnXJcJu1ZZ8bQthuUcdDWzDuxDdbSf6l1U6s4fP6EBiZpPsOZYqFOrbqDV97sXGFSsb6AUpiLfv4xIA==",
       "dev": true
     },
     "@types/through2": {
@@ -1700,14 +2673,14 @@
       "dev": true,
       "requires": {
         "@types/node": "6.0.64",
-        "@types/tapable": "1.0.2",
+        "@types/tapable": "0.2.4",
         "@types/uglify-js": "3.0.2"
       }
     },
     "@types/webpack-env": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.6.tgz",
-      "integrity": "sha512-5Th3OsZ4gTRdr9Mho83BQ23cex4sRhOR4XTG+m+cJc0FhtUBK9Vn62hBJ+pnQYnSxoPOsKoAPOx6FcphxBC8ng=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.1.tgz",
+      "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q=="
     },
     "@types/webpack-stream": {
       "version": "3.2.7",
@@ -1731,48 +2704,52 @@
       "integrity": "sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw="
     },
     "@uifabric/icons": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-5.2.0.tgz",
-      "integrity": "sha512-P5kfPej/wxgR8jZt/GqnU0FqYcz+JH1iCcaaYd6p9L3opmZtu4w5duKeqs+Bc1u7K16r800EQfLgKe76rt6AuA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-5.7.1.tgz",
+      "integrity": "sha512-UwfDU6A0bj/QAdTsO20g9mrKXo3zxvumkBWx0F0sEHn1DF/IQDiq4zYVBjRZ3NikQe2o7koWe3Gb0NR84Qr2Sg==",
       "requires": {
-        "@uifabric/styling": "5.25.0",
+        "@uifabric/styling": "5.31.0",
         "tslib": "1.8.1"
       }
     },
     "@uifabric/merge-styles": {
-      "version": "5.15.2",
-      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.15.2.tgz",
-      "integrity": "sha512-EF8V6s5vBh7jQ8WH3cCLCpIU6Z0yy05tV0eSY5YKIpQ7BB6E228Ty96U2WvA9ZNCHVM2iyf0ZeX+ooHlEvpKIg==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.17.1.tgz",
+      "integrity": "sha512-4/EtO6Ns7kNtKxC+6InShwVQeNQEDT5H8Ex7m/i4OrT9i7csje4YwBQPkkpm31qJwEZEyD7bbAwyLezI63sLhg==",
       "requires": {
         "tslib": "1.8.1"
       }
     },
     "@uifabric/styling": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.25.0.tgz",
-      "integrity": "sha512-jcu4m2OOWxATy5PxxYcGU/k0K4y/eS4EVyJeyjhU19kERoqWl9dJ+ZfIPVDEcIf6dSg6twpvIWwz3xT5pG/vjA==",
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.31.0.tgz",
+      "integrity": "sha512-NXGhTVrsIooKxTRWgPOfUEZGpgJKMyH/M43C80CaTDTp7yFwawpXurrfkyf5axv7Z+b4elQ7DHuQv0wNJ4N8Mg==",
       "requires": {
         "@microsoft/load-themed-styles": "1.7.53",
-        "@uifabric/merge-styles": "5.15.2",
-        "@uifabric/utilities": "5.25.0",
+        "@uifabric/merge-styles": "5.17.1",
+        "@uifabric/utilities": "5.33.0",
         "tslib": "1.8.1"
-      },
-      "dependencies": {
-        "@microsoft/load-themed-styles": {
-          "version": "1.7.53",
-          "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.53.tgz",
-          "integrity": "sha1-J7KoW8wJdoyOwrZS/9mIBCeah8U="
-        }
       }
     },
     "@uifabric/utilities": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.25.0.tgz",
-      "integrity": "sha512-CW2gZklqbyCp9BJFDdvYJ+V+xTlutZKq9oNSxQqh2owJZEYsca8woVvEUf/9Xzcbs9pg6Fs2IZCQbHZ/MFSXLw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.33.0.tgz",
+      "integrity": "sha512-BpErv7ukurDxCd1DrD4xOSe27PXZKivutnw7KVAuSdgTuou6jBEYjzVDZ3qn8LLd7v7g745EEcnDv5+27kjCWg==",
       "requires": {
-        "@uifabric/merge-styles": "5.15.2",
+        "@uifabric/merge-styles": "5.17.1",
         "prop-types": "15.6.1",
         "tslib": "1.8.1"
+      }
+    },
+    "@zkochan/cmd-shim": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@zkochan/cmd-shim/-/cmd-shim-2.2.4.tgz",
+      "integrity": "sha512-BDy1oz6aFYyY73618IkXzJzFghnXwVZDc3SVa6MVKTrrk4RgubahAF5yKK+Mx4a78tfO0OHeZnJKPs0pNy5uNA==",
+      "dev": true,
+      "requires": {
+        "is-windows": "1.0.2",
+        "mkdirp-promise": "5.0.1",
+        "mz": "2.7.0"
       }
     },
     "abab": {
@@ -1845,9 +2822,9 @@
       }
     },
     "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
       "dev": true
     },
     "align-text": {
@@ -1894,9 +2871,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
     "ansi-gray": {
@@ -1924,6 +2901,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
       "dev": true
     },
     "anymatch": {
@@ -2049,9 +3032,9 @@
       "dev": true
     },
     "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "requires": {
         "delegates": "1.0.0",
@@ -2233,6 +3216,23 @@
       "dev": true,
       "requires": {
         "util": "0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        }
       }
     },
     "assert-plus": {
@@ -2319,7 +3319,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000830",
+        "caniuse-db": "1.0.30000851",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -2634,14 +3634,13 @@
       }
     },
     "babel-jest": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
-      "integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
+      "integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
         "babel-plugin-istanbul": "4.1.6",
-        "babel-preset-jest": "20.0.3"
+        "babel-preset-jest": "21.2.0"
       }
     },
     "babel-messages": {
@@ -2666,9 +3665,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
-      "integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c=",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz",
+      "integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ==",
       "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -2700,12 +3699,13 @@
       }
     },
     "babel-preset-jest": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
-      "integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz",
+      "integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "20.0.3"
+        "babel-plugin-jest-hoist": "21.2.0",
+        "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
     "babel-register": {
@@ -2906,28 +3906,10 @@
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
-    "base64-url": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
-      "integrity": "sha1-GZ/WYXAqDnt9yubgaYuwicUvbXg=",
-      "dev": true
-    },
     "base64id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
-      "dev": true
-    },
-    "basic-auth": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz",
-      "integrity": "sha1-Awk1sB3nyblKgksp8/zLdQ06UpA=",
-      "dev": true
-    },
-    "basic-auth-connect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
-      "integrity": "sha1-/bC0OWLKe0BFanwrtI/hc9otISI=",
       "dev": true
     },
     "batch": {
@@ -3050,9 +4032,9 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
@@ -3060,19 +4042,38 @@
         "debug": "2.6.9",
         "depd": "1.1.2",
         "http-errors": "1.6.3",
-        "iconv-lite": "0.4.19",
+        "iconv-lite": "0.4.23",
         "on-finished": "2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
         "type-is": "1.6.16"
       },
       "dependencies": {
         "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         }
+      }
+    },
+    "bole": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bole/-/bole-3.0.2.tgz",
+      "integrity": "sha1-vIpIPKlASdqbg3wa0Rzf6+5uBRQ=",
+      "dev": true,
+      "requires": {
+        "fast-safe-stringify": "1.1.13",
+        "individual": "3.0.0"
       }
     },
     "boolbase": {
@@ -3246,7 +4247,7 @@
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000830"
+        "caniuse-db": "1.0.30000851"
       }
     },
     "bser": {
@@ -3265,7 +4266,7 @@
       "dev": true,
       "requires": {
         "base64-js": "1.3.0",
-        "ieee754": "1.1.11",
+        "ieee754": "1.1.12",
         "isarray": "1.0.0"
       },
       "dependencies": {
@@ -3395,16 +4396,25 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000830",
+        "caniuse-db": "1.0.30000851",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000830",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000830.tgz",
-      "integrity": "sha1-bkUlWzRWSf0V/1kHLaHhK7PeLxM=",
+      "version": "1.0.30000851",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000851.tgz",
+      "integrity": "sha1-ig08pN3nIGhWCsyYus91o1no0+M=",
       "dev": true
+    },
+    "capture-exit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+      "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+      "dev": true,
+      "requires": {
+        "rsvp": "3.6.2"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -3515,6 +4525,12 @@
           }
         }
       }
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true
     },
     "ci-info": {
       "version": "1.1.3",
@@ -3752,9 +4768,9 @@
       }
     },
     "colors": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
-      "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
       "dev": true
     },
     "combined-stream": {
@@ -3795,74 +4811,6 @@
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
-    "compressible": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
-      "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.33.0"
-      }
-    },
-    "compression": {
-      "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
-      "integrity": "sha1-sDuNhub4rSloPLqN+R3cb/x3s5U=",
-      "dev": true,
-      "requires": {
-        "accepts": "1.2.13",
-        "bytes": "2.1.0",
-        "compressible": "2.0.13",
-        "debug": "2.2.0",
-        "on-headers": "1.0.1",
-        "vary": "1.0.1"
-      },
-      "dependencies": {
-        "accepts": {
-          "version": "1.2.13",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-          "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
-          "dev": true,
-          "requires": {
-            "mime-types": "2.1.18",
-            "negotiator": "0.5.3"
-          }
-        },
-        "bytes": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
-          "integrity": "sha1-rJPEEOL/ycx89LRks4KJBn9eR7Q=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "negotiator": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-          "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g=",
-          "dev": true
-        },
-        "vary": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-          "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA=",
-          "dev": true
-        }
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3870,11 +4818,12 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
+        "buffer-from": "1.0.0",
         "inherits": "2.0.3",
         "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
@@ -3930,45 +4879,6 @@
       "integrity": "sha1-gBV9E3HJ83zBQDmrGJWXDRGdw7w=",
       "dev": true
     },
-    "connect-timeout": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
-      "integrity": "sha1-3ppexh4zoStu2qt7XwYumMWZuI4=",
-      "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "http-errors": "1.3.1",
-        "ms": "0.7.1",
-        "on-headers": "1.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "http-errors": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "statuses": "1.5.0"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -4020,24 +4930,6 @@
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
-    "cookie-parser": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
-      "integrity": "sha1-nXVVcPtdF4kHcSJ6AjFNm+fPg1Y=",
-      "dev": true,
-      "requires": {
-        "cookie": "0.1.3",
-        "cookie-signature": "1.0.6"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-          "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=",
-          "dev": true
-        }
-      }
-    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -4045,9 +4937,9 @@
       "dev": true
     },
     "cookiejar": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true
     },
     "copy-descriptor": {
@@ -4101,16 +4993,10 @@
         "subarg": "1.0.0"
       }
     },
-    "crc": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
-      "integrity": "sha1-+mIuG8OIvyVzCQgta2UgDOZwkLo=",
-      "dev": true
-    },
     "create-ecdh": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.1.tgz",
-      "integrity": "sha512-iZvCCg8XqHQZ1ioNBTzXS/cQSkqkqcPs8xSX4upNB+DAk9Ht3uzQf2J32uAHNCne8LDmKr29AgZrEs4oIrwLuQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -4217,7 +5103,7 @@
       "requires": {
         "browserify-cipher": "1.0.1",
         "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.1",
+        "create-ecdh": "4.0.3",
         "create-hash": "1.2.0",
         "create-hmac": "1.1.7",
         "diffie-hellman": "5.0.3",
@@ -4228,15 +5114,27 @@
         "randomfill": "1.0.4"
       }
     },
-    "csrf": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
-      "integrity": "sha1-thEg3c7q/JHnbtUxO7XAsmZ7cQo=",
+    "css": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.3.tgz",
+      "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
       "dev": true,
       "requires": {
-        "rndm": "1.2.0",
-        "tsscmp": "1.0.5",
-        "uid-safe": "2.1.4"
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.5.1",
+        "urix": "0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
       }
     },
     "css-color-names": {
@@ -4277,9 +5175,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-          "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -4299,16 +5197,16 @@
           "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
           "dev": true,
           "requires": {
-            "postcss": "6.0.21"
+            "postcss": "6.0.22"
           },
           "dependencies": {
             "postcss": {
-              "version": "6.0.21",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-              "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+              "version": "6.0.22",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+              "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
               "dev": true,
               "requires": {
-                "chalk": "2.4.0",
+                "chalk": "2.4.1",
                 "source-map": "0.6.1",
                 "supports-color": "5.4.0"
               }
@@ -4423,7 +5321,7 @@
         "postcss-discard-empty": "2.1.0",
         "postcss-discard-overridden": "0.1.1",
         "postcss-discard-unused": "2.2.3",
-        "postcss-filter-plugins": "2.0.2",
+        "postcss-filter-plugins": "2.0.3",
         "postcss-merge-idents": "2.1.7",
         "postcss-merge-longhand": "2.0.2",
         "postcss-merge-rules": "2.1.2",
@@ -4468,36 +5366,6 @@
         "cssom": "0.3.2"
       }
     },
-    "csurf": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
-      "integrity": "sha1-I/KhO/HY/OHQyZZYg5RELLqGpWo=",
-      "dev": true,
-      "requires": {
-        "cookie": "0.1.3",
-        "cookie-signature": "1.0.6",
-        "csrf": "3.0.6",
-        "http-errors": "1.3.1"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-          "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "statuses": "1.5.0"
-          }
-        }
-      }
-    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -4519,7 +5387,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.45"
       }
     },
     "dashdash": {
@@ -4589,9 +5457,9 @@
       "dev": true
     },
     "deasync": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.12.tgz",
-      "integrity": "sha512-gpacYo8FBZh3INBp2KOtrQp9kCO5faHvOmEZx3/cZTr3Mm8/kAYs7/Ws3E3OAH0ApBNK6Y6N+7+Dka2Zn2Fldw==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.13.tgz",
+      "integrity": "sha512-/6ngYM7AapueqLtvOzjv9+11N2fHDSrkxeMF1YPE20WIfaaawiBg+HZH1E5lHrcJxlKR42t6XPOEmMmqcAsU1g==",
       "dev": true,
       "requires": {
         "bindings": "1.2.1",
@@ -4605,6 +5473,28 @@
       "dev": true,
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "debug-fabulous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.1.0.tgz",
+      "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0",
+        "memoizee": "0.4.12",
+        "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "debuglog": {
@@ -4960,9 +5850,9 @@
       }
     },
     "duplexify": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
-      "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "dev": true,
       "requires": {
         "end-of-stream": "1.1.0",
@@ -5020,9 +5910,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.42",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
-      "integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk=",
+      "version": "1.3.48",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
+      "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA=",
       "dev": true
     },
     "elliptic": {
@@ -5276,16 +6166,6 @@
         "is-arrayish": "0.2.1"
       }
     },
-    "errorhandler": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
-      "integrity": "sha1-t7cO2PNZ6duICS8tIMD4MUIK2D8=",
-      "dev": true,
-      "requires": {
-        "accepts": "1.3.3",
-        "escape-html": "1.0.3"
-      }
-    },
     "es-abstract": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
@@ -5311,9 +6191,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.42",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
-      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+      "version": "0.10.45",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
+      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -5333,7 +6213,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.45",
         "es6-symbol": "3.1.1"
       }
     },
@@ -5344,7 +6224,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.45",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -5363,7 +6243,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.45",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -5376,7 +6256,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.45"
       }
     },
     "es6-templates": {
@@ -5396,7 +6276,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.45",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -5481,9 +6361,9 @@
       "dev": true
     },
     "etag": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-      "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "event-emitter": {
@@ -5493,7 +6373,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.45"
       }
     },
     "event-stream": {
@@ -5512,9 +6392,9 @@
       }
     },
     "eventemitter3": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.1.tgz",
-      "integrity": "sha512-QOCPu979MMWX9XNlfRZoin+Wm+bK1SP7vv3NGUniYwuSJK/+cPA10blMaeRgzg31RvoSFk6FsCDVa4vNryBTGA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
       "dev": true
     },
     "events": {
@@ -5925,144 +6805,134 @@
       }
     },
     "express": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.14.1.tgz",
-      "integrity": "sha1-ZGwjf3ZvFIwhIK/wc4F7nk1+DTM=",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.3",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
         "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.2.0",
+        "debug": "2.6.9",
         "depd": "1.1.2",
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
-        "etag": "1.7.0",
-        "finalhandler": "0.5.1",
-        "fresh": "0.3.0",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.2.0",
+        "proxy-addr": "2.0.3",
+        "qs": "6.5.1",
         "range-parser": "1.2.0",
-        "send": "0.14.2",
-        "serve-static": "1.11.2",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.4.0",
         "type-is": "1.6.16",
-        "utils-merge": "1.0.0",
+        "utils-merge": "1.0.1",
         "vary": "1.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+        "accepts": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+          "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "mime-types": "2.1.18",
+            "negotiator": "0.6.1"
+          }
+        },
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.16"
           }
         },
         "finalhandler": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz",
-          "integrity": "sha1-LEANjUUwk1vCMlScX6OF7Afeb80=",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+          "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "dev": true,
           "requires": {
-            "debug": "2.2.0",
+            "debug": "2.6.9",
+            "encodeurl": "1.0.2",
             "escape-html": "1.0.3",
             "on-finished": "2.3.0",
-            "statuses": "1.3.1",
+            "parseurl": "1.3.2",
+            "statuses": "1.4.0",
             "unpipe": "1.0.0"
           }
         },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
           "dev": true
         },
-        "qs": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
-          "integrity": "sha1-O3hIwDwt7OaalSKw+ujEEm10Xzs=",
-          "dev": true
+        "raw-body": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+              "dev": true
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "dev": true,
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+              "dev": true
+            }
+          }
         },
         "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-          "dev": true
-        },
-        "utils-merge": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
-          "dev": true
-        }
-      }
-    },
-    "express-session": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
-      "integrity": "sha1-XMmPP1/4Ttg1+Ry/CqvQxxB0AK8=",
-      "dev": true,
-      "requires": {
-        "cookie": "0.1.3",
-        "cookie-signature": "1.0.6",
-        "crc": "3.3.0",
-        "debug": "2.2.0",
-        "depd": "1.0.1",
-        "on-headers": "1.0.1",
-        "parseurl": "1.3.2",
-        "uid-safe": "2.0.0",
-        "utils-merge": "1.0.0"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-          "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "depd": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-          "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "uid-safe": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
-          "integrity": "sha1-p/PGymSh9qXQTsDvPkw9U2cxcTc=",
-          "dev": true,
-          "requires": {
-            "base64-url": "1.2.1"
-          }
-        },
-        "utils-merge": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
       }
@@ -6182,32 +7052,15 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
-      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "debug": "2.6.9",
-        "mkdirp": "0.5.0",
+        "mkdirp": "0.5.1",
         "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        }
       }
     },
     "extsprintf": {
@@ -6243,6 +7096,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-1.1.13.tgz",
+      "integrity": "sha1-oB6c2cnkkXFcmKdaQtXwu9EH/3Y=",
       "dev": true
     },
     "fastparse": {
@@ -6313,21 +7172,27 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
+          "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "1.1.0",
+            "fast-deep-equal": "2.0.1",
             "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1",
-            "uri-js": "3.0.2"
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
           }
         },
-        "ajv-keywords": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
-          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "schema-utils": {
@@ -6336,8 +7201,8 @@
           "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
           "dev": true,
           "requires": {
-            "ajv": "6.4.0",
-            "ajv-keywords": "3.1.0"
+            "ajv": "6.5.1",
+            "ajv-keywords": "3.2.0"
           }
         }
       }
@@ -6463,9 +7328,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
-      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
       "dev": true,
       "requires": {
         "debug": "3.1.0"
@@ -6557,9 +7422,9 @@
       }
     },
     "fresh": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-      "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "from": {
@@ -6579,6 +7444,15 @@
         "klaw": "1.3.1",
         "path-is-absolute": "1.0.1",
         "rimraf": "2.5.4"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "dev": true,
+      "requires": {
+        "minipass": "2.3.3"
       }
     },
     "fs.realpath": {
@@ -6629,7 +7503,7 @@
         "signal-exit": "3.0.2",
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "wide-align": "1.1.3"
       }
     },
     "gaze": {
@@ -7324,87 +8198,22 @@
       }
     },
     "gulp-connect": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-connect/-/gulp-connect-5.0.0.tgz",
-      "integrity": "sha1-8v3zBq6RFGg2jCKF8teC8T7dr04=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/gulp-connect/-/gulp-connect-5.5.0.tgz",
+      "integrity": "sha512-oRBLjw/4EVaZb8g8OcxOVdGD8ZXYrRiWKcNxlrGjxb/6Cp0GDdqw7ieX7D8xJrQS7sbXT+G94u63pMJF3MMjQA==",
       "dev": true,
       "requires": {
-        "connect": "2.30.2",
+        "ansi-colors": "1.1.0",
+        "connect": "3.6.6",
         "connect-livereload": "0.5.4",
         "event-stream": "3.3.4",
-        "gulp-util": "3.0.8",
+        "fancy-log": "1.3.2",
+        "send": "0.13.2",
+        "serve-index": "1.9.1",
+        "serve-static": "1.13.2",
         "tiny-lr": "0.2.1"
       },
       "dependencies": {
-        "body-parser": {
-          "version": "1.13.3",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
-          "integrity": "sha1-wIzzMMM1jhUQFqBXRvE/ApyX+pc=",
-          "dev": true,
-          "requires": {
-            "bytes": "2.1.0",
-            "content-type": "1.0.4",
-            "debug": "2.2.0",
-            "depd": "1.0.1",
-            "http-errors": "1.3.1",
-            "iconv-lite": "0.4.11",
-            "on-finished": "2.3.0",
-            "qs": "4.0.0",
-            "raw-body": "2.1.7",
-            "type-is": "1.6.16"
-          }
-        },
-        "bytes": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
-          "integrity": "sha1-rJPEEOL/ycx89LRks4KJBn9eR7Q=",
-          "dev": true
-        },
-        "connect": {
-          "version": "2.30.2",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
-          "integrity": "sha1-jam8vooFTT0xjXTf7JA7XDmhtgk=",
-          "dev": true,
-          "requires": {
-            "basic-auth-connect": "1.0.0",
-            "body-parser": "1.13.3",
-            "bytes": "2.1.0",
-            "compression": "1.5.2",
-            "connect-timeout": "1.6.2",
-            "content-type": "1.0.4",
-            "cookie": "0.1.3",
-            "cookie-parser": "1.3.5",
-            "cookie-signature": "1.0.6",
-            "csurf": "1.8.3",
-            "debug": "2.2.0",
-            "depd": "1.0.1",
-            "errorhandler": "1.4.3",
-            "express-session": "1.11.3",
-            "finalhandler": "0.4.0",
-            "fresh": "0.3.0",
-            "http-errors": "1.3.1",
-            "method-override": "2.3.10",
-            "morgan": "1.6.1",
-            "multiparty": "3.3.2",
-            "on-headers": "1.0.1",
-            "parseurl": "1.3.2",
-            "pause": "0.1.0",
-            "qs": "4.0.0",
-            "response-time": "2.3.2",
-            "serve-favicon": "2.3.2",
-            "serve-index": "1.7.3",
-            "serve-static": "1.10.3",
-            "type-is": "1.6.16",
-            "utils-merge": "1.0.0",
-            "vhost": "3.0.2"
-          }
-        },
-        "cookie": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-          "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=",
-          "dev": true
-        },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -7414,16 +8223,10 @@
             "ms": "0.7.1"
           }
         },
-        "depd": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-          "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo=",
-          "dev": true
-        },
-        "escape-html": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
-          "integrity": "sha1-130y+pjjjC9BroXpJ44ODmuhAiw=",
+        "etag": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+          "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
           "dev": true
         },
         "event-stream": {
@@ -7441,17 +8244,11 @@
             "through": "2.3.8"
           }
         },
-        "finalhandler": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
-          "integrity": "sha1-llpS2ejQXSuFdUhUH7ibU6JJfZs=",
-          "dev": true,
-          "requires": {
-            "debug": "2.2.0",
-            "escape-html": "1.0.2",
-            "on-finished": "2.3.0",
-            "unpipe": "1.0.0"
-          }
+        "fresh": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+          "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
+          "dev": true
         },
         "http-errors": {
           "version": "1.3.1",
@@ -7460,14 +8257,8 @@
           "dev": true,
           "requires": {
             "inherits": "2.0.3",
-            "statuses": "1.5.0"
+            "statuses": "1.2.1"
           }
-        },
-        "iconv-lite": {
-          "version": "0.4.11",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
-          "integrity": "sha1-LstC/SlHRJIiCaLnxATayHk9it4=",
-          "dev": true
         },
         "map-stream": {
           "version": "0.1.0",
@@ -7487,42 +8278,11 @@
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
-        "qs": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
-          "dev": true
-        },
         "range-parser": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
           "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU=",
           "dev": true
-        },
-        "raw-body": {
-          "version": "2.1.7",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
-          "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
-          "dev": true,
-          "requires": {
-            "bytes": "2.4.0",
-            "iconv-lite": "0.4.13",
-            "unpipe": "1.0.0"
-          },
-          "dependencies": {
-            "bytes": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-              "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
-              "dev": true
-            },
-            "iconv-lite": {
-              "version": "0.4.13",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-              "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
-              "dev": true
-            }
-          }
         },
         "send": {
           "version": "0.13.2",
@@ -7542,45 +8302,6 @@
             "on-finished": "2.3.0",
             "range-parser": "1.0.3",
             "statuses": "1.2.1"
-          },
-          "dependencies": {
-            "depd": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-              "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-              "dev": true
-            },
-            "escape-html": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-              "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-              "dev": true
-            },
-            "statuses": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-              "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg=",
-              "dev": true
-            }
-          }
-        },
-        "serve-static": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
-          "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
-          "dev": true,
-          "requires": {
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.2",
-            "send": "0.13.2"
-          },
-          "dependencies": {
-            "escape-html": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-              "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-              "dev": true
-            }
           }
         },
         "split": {
@@ -7592,10 +8313,10 @@
             "through": "2.3.8"
           }
         },
-        "utils-merge": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+        "statuses": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg=",
           "dev": true
         }
       }
@@ -7843,7 +8564,7 @@
       "integrity": "sha1-oW9n6VzqiyBhtjo7jDibxVm44c4=",
       "dev": true,
       "requires": {
-        "colors": "1.2.1",
+        "colors": "1.2.5",
         "gulp-util": "3.0.8",
         "open": "0.0.5",
         "through2": "2.0.3"
@@ -7922,43 +8643,41 @@
       "requires": {
         "gulp-util": "3.0.8",
         "lodash.clonedeep": "4.5.0",
-        "node-sass": "4.8.3",
+        "node-sass": "4.9.0",
         "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "gulp-sourcemaps": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-      "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.4.tgz",
+      "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
       "dev": true,
       "requires": {
+        "@gulp-sourcemaps/identity-map": "1.0.1",
+        "@gulp-sourcemaps/map-sources": "1.0.0",
+        "acorn": "5.6.2",
         "convert-source-map": "1.5.1",
+        "css": "2.2.3",
+        "debug-fabulous": "1.1.0",
+        "detect-newline": "2.1.0",
         "graceful-fs": "4.1.11",
-        "strip-bom": "2.0.0",
-        "through2": "2.0.3",
-        "vinyl": "1.2.0"
+        "source-map": "0.6.1",
+        "strip-bom-string": "1.0.0",
+        "through2": "2.0.3"
       },
       "dependencies": {
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+        "acorn": {
+          "version": "5.6.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
+          "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
+          "dev": true
         },
-        "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true,
-          "requires": {
-            "clone": "1.0.4",
-            "clone-stats": "0.0.1",
-            "replace-ext": "0.0.1"
-          }
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -8143,6 +8862,19 @@
             }
           }
         },
+        "gulp-sourcemaps": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+          "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+          "dev": true,
+          "requires": {
+            "convert-source-map": "1.5.1",
+            "graceful-fs": "4.1.11",
+            "strip-bom": "2.0.0",
+            "through2": "2.0.3",
+            "vinyl": "1.2.0"
+          }
+        },
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
@@ -8266,7 +8998,7 @@
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "dev": true,
           "requires": {
-            "duplexify": "3.5.4",
+            "duplexify": "3.6.0",
             "glob-stream": "5.3.5",
             "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
@@ -8586,15 +9318,15 @@
       "requires": {
         "es6-templates": "0.2.3",
         "fastparse": "1.1.1",
-        "html-minifier": "3.5.15",
+        "html-minifier": "3.5.16",
         "loader-utils": "1.1.0",
         "object-assign": "4.1.1"
       }
     },
     "html-minifier": {
-      "version": "3.5.15",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.15.tgz",
-      "integrity": "sha512-OZa4rfb6tZOZ3Z8Xf0jKxXkiDcFWldQePGYFDcgKqES2sXeWaEv9y6QQvWUtX3ySI3feApQi5uCsHLINQ6NoAw==",
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.16.tgz",
+      "integrity": "sha512-zP5EfLSpiLRp0aAgud4CQXPQZm9kXwWjR/cF0PfdOj+jjWnOaCgeZcll4kYXSvIBPeUMmyaSc7mM4IDtA+kboA==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
@@ -8603,7 +9335,7 @@
         "he": "1.1.1",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.3.21"
+        "uglify-js": "3.3.28"
       },
       "dependencies": {
         "source-map": {
@@ -8613,9 +9345,9 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.3.21",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.21.tgz",
-          "integrity": "sha512-uy82472lH8tshK3jS3c5IFb5MmNKd/5qyBd0ih8sM42L3jWvxnE339U9gZU1zufnLVs98Stib9twq8dLm2XYCA==",
+          "version": "3.3.28",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.28.tgz",
+          "integrity": "sha512-68Rc/aA6cswiaQ5SrE979UJcXX+ADA1z33/ZsPd+fbAiVdjZ16OXdbtGO+rJUUBgK6qdf3SOPhQf3K/ybF5Miw==",
           "dev": true,
           "requires": {
             "commander": "2.15.1",
@@ -8683,9 +9415,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
-      "integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA==",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
+      "integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc=",
       "dev": true
     },
     "http-proxy": {
@@ -8694,8 +9426,8 @@
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "dev": true,
       "requires": {
-        "eventemitter3": "3.0.1",
-        "follow-redirects": "1.4.1",
+        "eventemitter3": "3.1.0",
+        "follow-redirects": "1.5.0",
         "requires-port": "1.0.0"
       }
     },
@@ -8736,7 +9468,7 @@
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.21"
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8749,9 +9481,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-          "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -8766,12 +9498,12 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+          "version": "6.0.22",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.0",
+            "chalk": "2.4.1",
             "source-map": "0.6.1",
             "supports-color": "5.4.0"
           }
@@ -8803,9 +9535,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
       "dev": true
     },
     "import-local": {
@@ -8851,6 +9583,12 @@
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
+    "individual": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
+      "integrity": "sha1-58pPhfiVewGHNPKFdQ3CLsL5hi0=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -8891,7 +9629,7 @@
         "cli-width": "2.2.0",
         "external-editor": "1.1.1",
         "figures": "1.7.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "mute-stream": "0.0.6",
         "pinkie-promise": "2.0.1",
         "run-async": "2.3.0",
@@ -8901,10 +9639,16 @@
         "through": "2.3.8"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         },
         "mute-stream": {
@@ -8937,9 +9681,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
       "dev": true
     },
     "is": {
@@ -10849,233 +11593,156 @@
       }
     },
     "jest-changed-files": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
-      "integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g=",
-      "dev": true
-    },
-    "jest-cli": {
-      "version": "20.0.4",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
-      "integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.2.0.tgz",
+      "integrity": "sha512-+lCNP1IZLwN1NOIvBcV5zEL6GENK6TXrDj4UxWIeLvIsIDa+gf6J7hkqsW2qVVt/wvH65rVvcPwqXdps5eclTQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "callsites": "2.0.0",
-        "chalk": "1.1.3",
-        "graceful-fs": "4.1.11",
-        "is-ci": "1.1.0",
-        "istanbul-api": "1.3.1",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-source-maps": "1.2.3",
-        "jest-changed-files": "20.0.3",
-        "jest-config": "20.0.4",
-        "jest-docblock": "20.0.3",
-        "jest-environment-jsdom": "20.0.3",
-        "jest-haste-map": "20.0.5",
-        "jest-jasmine2": "20.0.4",
-        "jest-message-util": "20.0.3",
-        "jest-regex-util": "20.0.3",
-        "jest-resolve-dependencies": "20.0.3",
-        "jest-runtime": "20.0.4",
-        "jest-snapshot": "20.0.3",
-        "jest-util": "20.0.3",
-        "micromatch": "2.3.11",
-        "node-notifier": "5.0.2",
-        "pify": "2.3.0",
-        "slash": "1.0.0",
-        "string-length": "1.0.1",
-        "throat": "3.2.0",
-        "which": "1.3.0",
-        "worker-farm": "1.6.0",
-        "yargs": "7.1.0"
+        "throat": "4.1.0"
+      }
+    },
+    "jest-config": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz",
+      "integrity": "sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "glob": "7.1.2",
+        "jest-environment-jsdom": "21.2.1",
+        "jest-environment-node": "21.2.1",
+        "jest-get-type": "21.2.0",
+        "jest-jasmine2": "21.2.1",
+        "jest-regex-util": "21.2.0",
+        "jest-resolve": "21.2.0",
+        "jest-util": "21.2.1",
+        "jest-validate": "21.2.1",
+        "pretty-format": "21.2.1"
       },
       "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "color-convert": "1.9.1"
           }
         },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
-        "camelcase": {
+        "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+        "jest-get-type": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+          "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
           "dev": true
         },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
-          }
-        },
-        "yargs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-          "dev": true,
-          "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
     },
-    "jest-config": {
-      "version": "20.0.4",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
-      "integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "glob": "7.1.2",
-        "jest-environment-jsdom": "20.0.3",
-        "jest-environment-node": "20.0.3",
-        "jest-jasmine2": "20.0.4",
-        "jest-matcher-utils": "20.0.3",
-        "jest-regex-util": "20.0.3",
-        "jest-resolve": "20.0.4",
-        "jest-validate": "20.0.3",
-        "pretty-format": "20.0.3"
-      }
-    },
     "jest-diff": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
-      "integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
+      "integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "2.4.1",
         "diff": "3.5.0",
-        "jest-matcher-utils": "20.0.3",
-        "pretty-format": "20.0.3"
+        "jest-get-type": "21.2.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "jest-get-type": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+          "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "jest-docblock": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
-      "integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI=",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
       "dev": true
     },
     "jest-environment-jsdom": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
-      "integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz",
+      "integrity": "sha512-mecaeNh0eWmzNrUNMWARysc0E9R96UPBamNiOCYL28k7mksb1d0q6DD38WKP7ABffjnXyUWJPVaWRgUOivwXwg==",
       "dev": true,
       "requires": {
-        "jest-mock": "20.0.3",
-        "jest-util": "20.0.3",
+        "jest-mock": "21.2.0",
+        "jest-util": "21.2.1",
         "jsdom": "9.12.0"
       }
     },
     "jest-environment-node": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
-      "integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz",
+      "integrity": "sha512-R211867wx9mVBVHzrjGRGTy5cd05K7eqzQl/WyZixR/VkJ4FayS8qkKXZyYnwZi6Rxo6WEV81cDbiUx/GfuLNw==",
       "dev": true,
       "requires": {
-        "jest-mock": "20.0.3",
-        "jest-util": "20.0.3"
+        "jest-mock": "21.2.0",
+        "jest-util": "21.2.1"
       }
     },
     "jest-get-type": {
@@ -11085,16 +11752,16 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "20.0.5",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.5.tgz",
-      "integrity": "sha512-0IKAQjUvuZjMCNi/0VNQQF74/H9KB67hsHJqGiwTWQC6XO5Azs7kLWm+6Q/dwuhvDUvABDOBMFK2/FwZ3sZ07Q==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz",
+      "integrity": "sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
-        "jest-docblock": "20.0.3",
+        "jest-docblock": "21.2.0",
         "micromatch": "2.3.11",
-        "sane": "1.6.0",
+        "sane": "2.5.2",
         "worker-farm": "1.6.0"
       },
       "dependencies": {
@@ -11190,20 +11857,76 @@
       }
     },
     "jest-jasmine2": {
-      "version": "20.0.4",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
-      "integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz",
+      "integrity": "sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "2.4.1",
+        "expect": "21.2.1",
         "graceful-fs": "4.1.11",
-        "jest-diff": "20.0.3",
-        "jest-matcher-utils": "20.0.3",
-        "jest-matchers": "20.0.3",
-        "jest-message-util": "20.0.3",
-        "jest-snapshot": "20.0.3",
-        "once": "1.4.0",
-        "p-map": "1.2.0"
+        "jest-diff": "21.2.1",
+        "jest-matcher-utils": "21.2.1",
+        "jest-message-util": "21.2.1",
+        "jest-snapshot": "21.2.1",
+        "p-cancelable": "0.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "expect": {
+          "version": "21.2.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-21.2.1.tgz",
+          "integrity": "sha512-orfQQqFRTX0jH7znRIGi8ZMR8kTNpXklTTz8+HGTpmTKZo3Occ6JNB5FXMb8cRuiiC/GyDqsr30zUa66ACYlYw==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "jest-diff": "21.2.1",
+            "jest-get-type": "21.2.0",
+            "jest-matcher-utils": "21.2.1",
+            "jest-message-util": "21.2.1",
+            "jest-regex-util": "21.2.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "jest-get-type": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+          "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "jest-junit": {
@@ -11271,38 +11994,79 @@
       }
     },
     "jest-matcher-utils": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
-      "integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
+      "integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "pretty-format": "20.0.3"
-      }
-    },
-    "jest-matchers": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
-      "integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
-      "dev": true,
-      "requires": {
-        "jest-diff": "20.0.3",
-        "jest-matcher-utils": "20.0.3",
-        "jest-message-util": "20.0.3",
-        "jest-regex-util": "20.0.3"
+        "chalk": "2.4.1",
+        "jest-get-type": "21.2.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "jest-get-type": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+          "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "jest-message-util": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
-      "integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz",
+      "integrity": "sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "2.4.1",
         "micromatch": "2.3.11",
         "slash": "1.0.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
         "arr-diff": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -11329,6 +12093,17 @@
             "repeat-element": "1.1.2"
           }
         },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
         "expand-brackets": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -11346,6 +12121,12 @@
           "requires": {
             "is-extglob": "1.0.0"
           }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
@@ -11391,39 +12172,85 @@
             "parse-glob": "3.0.4",
             "regex-cache": "0.4.4"
           }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
         }
       }
     },
     "jest-mock": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
-      "integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk=",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz",
+      "integrity": "sha512-aZDfyVf0LEoABWiY6N0d+O963dUQSyUa4qgzurHR3TBDPen0YxKCJ6l2i7lQGh1tVdsuvdrCZ4qPj+A7PievCw==",
       "dev": true
     },
     "jest-regex-util": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
-      "integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I=",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz",
+      "integrity": "sha512-BKQ1F83EQy0d9Jen/mcVX7D+lUt2tthhK/2gDWRgLDJRNOdRgSp1iVqFxP8EN1ARuypvDflRfPzYT8fQnoBQFQ==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "20.0.4",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
-      "integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz",
+      "integrity": "sha512-vefQ/Lr+VdNvHUZFQXWtOqHX3HEdOc2MtSahBO89qXywEbUxGPB9ZLP9+BHinkxb60UT2Q/tTDOS6rYc6Mwigw==",
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
-        "is-builtin-module": "1.0.0",
-        "resolve": "1.7.1"
+        "chalk": "2.4.1",
+        "is-builtin-module": "1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "jest-resolve-dependencies": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
-      "integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz",
+      "integrity": "sha512-ok8ybRFU5ScaAcfufIQrCbdNJSRZ85mkxJ1EhUp8Bhav1W1/jv/rl1Q6QoVQHObNxmKnbHVKrfLZbCbOsXQ+bQ==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "20.0.3"
+        "jest-regex-util": "21.2.0"
       }
     },
     "jest-runner": {
@@ -12528,28 +13355,45 @@
       }
     },
     "jest-runtime": {
-      "version": "20.0.4",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
-      "integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz",
+      "integrity": "sha512-6omlpA3+NSE+rHwD0PQjNEjZeb2z+oRmuehMfM1tWQVum+E0WV3pFt26Am0DUfQkkPyTABvxITRjCUclYgSOsA==",
       "dev": true,
       "requires": {
         "babel-core": "6.26.0",
-        "babel-jest": "20.0.3",
+        "babel-jest": "21.2.0",
         "babel-plugin-istanbul": "4.1.6",
-        "chalk": "1.1.3",
+        "chalk": "2.4.1",
         "convert-source-map": "1.5.1",
         "graceful-fs": "4.1.11",
-        "jest-config": "20.0.4",
-        "jest-haste-map": "20.0.5",
-        "jest-regex-util": "20.0.3",
-        "jest-resolve": "20.0.4",
-        "jest-util": "20.0.3",
+        "jest-config": "21.2.1",
+        "jest-haste-map": "21.2.0",
+        "jest-regex-util": "21.2.0",
+        "jest-resolve": "21.2.0",
+        "jest-util": "21.2.1",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
+        "slash": "1.0.0",
         "strip-bom": "3.0.0",
-        "yargs": "7.1.0"
+        "write-file-atomic": "2.3.0",
+        "yargs": "9.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
         "arr-diff": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -12577,10 +13421,21 @@
           }
         },
         "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
         },
         "cliui": {
           "version": "3.2.0",
@@ -12591,6 +13446,19 @@
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1",
             "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
           }
         },
         "expand-brackets": {
@@ -12610,6 +13478,12 @@
           "requires": {
             "is-extglob": "1.0.0"
           }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
@@ -12635,6 +13509,18 @@
             "is-buffer": "1.1.6"
           }
         },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
         "micromatch": {
           "version": "2.3.11",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -12656,31 +13542,97 @@
             "regex-cache": "0.4.4"
           }
         },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
-        "yargs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
+            "has-flag": "3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+          "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
             "cliui": "3.2.0",
             "decamelize": "1.2.0",
             "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
             "require-directory": "2.1.1",
             "require-main-filename": "1.0.1",
             "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
             "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "yargs-parser": "7.0.0"
           }
         }
       }
@@ -12692,44 +13644,161 @@
       "dev": true
     },
     "jest-snapshot": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
-      "integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz",
+      "integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "jest-diff": "20.0.3",
-        "jest-matcher-utils": "20.0.3",
-        "jest-util": "20.0.3",
+        "chalk": "2.4.1",
+        "jest-diff": "21.2.1",
+        "jest-matcher-utils": "21.2.1",
+        "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
-        "pretty-format": "20.0.3"
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "jest-util": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
-      "integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz",
+      "integrity": "sha512-r20W91rmHY3fnCoO7aOAlyfC51x2yeV3xF+prGsJAUsYhKeV670ZB8NO88Lwm7ASu8SdH0S+U+eFf498kjhA4g==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "callsites": "2.0.0",
+        "chalk": "2.4.1",
         "graceful-fs": "4.1.11",
-        "jest-message-util": "20.0.3",
-        "jest-mock": "20.0.3",
-        "jest-validate": "20.0.3",
-        "leven": "2.1.0",
+        "jest-message-util": "21.2.1",
+        "jest-mock": "21.2.0",
+        "jest-validate": "21.2.1",
         "mkdirp": "0.5.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "jest-validate": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
-      "integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "jest-matcher-utils": "20.0.3",
+        "chalk": "2.4.1",
+        "jest-get-type": "21.2.0",
         "leven": "2.1.0",
-        "pretty-format": "20.0.3"
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "jest-get-type": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+          "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "jest-worker": {
@@ -12748,9 +13817,9 @@
       "dev": true
     },
     "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",
+      "integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ==",
       "dev": true
     },
     "js-tokens": {
@@ -12931,11 +14000,11 @@
       "requires": {
         "batch": "0.5.3",
         "bluebird": "2.11.0",
-        "body-parser": "1.18.2",
+        "body-parser": "1.18.3",
         "chokidar": "1.7.0",
-        "colors": "1.2.1",
+        "colors": "1.2.5",
         "connect": "3.6.6",
-        "core-js": "2.5.5",
+        "core-js": "2.5.7",
         "di": "0.0.1",
         "dom-serialize": "2.2.1",
         "expand-braces": "0.1.2",
@@ -12955,9 +14024,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
           "dev": true
         },
         "lodash": {
@@ -13016,14 +14085,14 @@
       "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "phantomjs-prebuilt": "2.1.16"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
@@ -13046,23 +14115,40 @@
       }
     },
     "karma-webpack": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.13.tgz",
-      "integrity": "sha512-2cyII34jfrAabbI2+4Rk4j95Nazl98FvZQhgSiqKUDarT317rxfv/EdzZ60CyATN4PQxJdO5ucR5bOOXkEVrXw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.9.tgz",
+      "integrity": "sha512-F1j3IG/XhiMzcunAXbWXH95uizjzr3WdTzmVWlta8xqxcCtAu9FByCb4sccIMxaVFAefpgnUW9KlCo0oLvIX6A==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "babel-runtime": "6.26.0",
-        "loader-utils": "1.1.0",
-        "lodash": "4.17.5",
+        "async": "0.9.2",
+        "loader-utils": "0.2.17",
+        "lodash": "3.10.1",
         "source-map": "0.5.7",
         "webpack-dev-middleware": "1.12.2"
       },
       "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
       }
@@ -13704,11 +14790,14 @@
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
-    "macaddress": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
-      "dev": true
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.45"
+      }
     },
     "make-iterator": {
       "version": "1.0.1",
@@ -13795,6 +14884,22 @@
       "dev": true,
       "requires": {
         "mimic-fn": "1.2.0"
+      }
+    },
+    "memoizee": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.12.tgz",
+      "integrity": "sha512-sprBu6nwxBWBvBOh5v2jcsGqiGLlL2xr2dLub3vR8dnE8YB17omwtm/0NSHl8jjNbcsJd5GMWJAnTSVe/O0Wfg==",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.45",
+        "es6-weak-map": "2.0.2",
+        "event-emitter": "0.3.5",
+        "is-promise": "2.1.0",
+        "lru-queue": "0.1.0",
+        "next-tick": "1.0.0",
+        "timers-ext": "0.1.5"
       }
     },
     "memory-fs": {
@@ -13916,18 +15021,6 @@
       "integrity": "sha1-+kT4siYmFaty8ICKQB1HinDjlNs=",
       "dev": true
     },
-    "method-override": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.10.tgz",
-      "integrity": "sha1-49r41d7hDdLc59SuiNYrvud0drQ=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "methods": "1.1.2",
-        "parseurl": "1.3.2",
-        "vary": "1.1.2"
-      }
-    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -14020,13 +15113,27 @@
       "dev": true
     },
     "minipass": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-      "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
+      "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "yallist": "3.0.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "dev": true
+        }
       }
     },
     "minizlib": {
@@ -14035,7 +15142,7 @@
       "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "dev": true,
       "requires": {
-        "minipass": "2.2.4"
+        "minipass": "2.3.3"
       }
     },
     "mixin-deep": {
@@ -14074,6 +15181,15 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
+      }
+    },
+    "mkdirp-promise": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
+      "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
       }
     },
     "mocha": {
@@ -14156,57 +15272,11 @@
       "integrity": "sha1-CbaYXDIYFhQDIeED593ktIdgkhw=",
       "dev": true
     },
-    "morgan": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
-      "integrity": "sha1-X9gYOYxoGcuiinzWZk8pL+HAu/I=",
-      "dev": true,
-      "requires": {
-        "basic-auth": "1.0.4",
-        "debug": "2.2.0",
-        "depd": "1.0.1",
-        "on-finished": "2.3.0",
-        "on-headers": "1.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "depd": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-          "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
-    },
-    "multiparty": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
-      "integrity": "sha1-Nd5oBNwZZD5SSfPT473GyM4wHT8=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "1.1.14",
-        "stream-counter": "0.2.0"
-      }
     },
     "multipipe": {
       "version": "0.1.2",
@@ -14222,6 +15292,17 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0",
+        "object-assign": "4.1.1",
+        "thenify-all": "1.6.0"
+      }
     },
     "nan": {
       "version": "2.10.0",
@@ -14260,6 +15341,18 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "ndjson": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
+      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
+      "dev": true,
+      "requires": {
+        "json-stringify-safe": "5.0.1",
+        "minimist": "1.2.0",
+        "split2": "2.2.0",
+        "through2": "2.0.3"
+      }
     },
     "nearley": {
       "version": "2.13.0",
@@ -14354,24 +15447,172 @@
       "dev": true
     },
     "node-gyp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
-      "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
+      "integrity": "sha512-qDQE/Ft9xXP6zphwx4sD0t+VhwV7yFaloMpfbL2QnnDZcyaiakWlLdtFGGQfTAwpFHdpbRhRxVhIHN1OKAjgbg==",
       "dev": true,
       "requires": {
         "fstream": "1.0.11",
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
         "npmlog": "4.1.2",
         "osenv": "0.1.5",
-        "request": "2.85.0",
+        "request": "2.81.0",
         "rimraf": "2.5.4",
         "semver": "5.3.0",
         "tar": "2.2.1",
         "which": "1.3.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "dev": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
+          }
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        }
       }
     },
     "node-int64": {
@@ -14402,12 +15643,12 @@
         "querystring-es3": "0.2.1",
         "readable-stream": "2.3.6",
         "stream-browserify": "2.0.1",
-        "stream-http": "2.8.1",
+        "stream-http": "2.8.3",
         "string_decoder": "1.1.1",
         "timers-browserify": "2.0.10",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
-        "util": "0.10.3",
+        "util": "0.10.4",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -14440,6 +15681,15 @@
           "requires": {
             "safe-buffer": "5.1.1"
           }
+        },
+        "util": {
+          "version": "0.10.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+          "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
         }
       }
     },
@@ -14456,15 +15706,15 @@
       }
     },
     "node-sass": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.8.3.tgz",
-      "integrity": "sha512-tfFWhUsCk/Y19zarDcPo5xpj+IW3qCfOjVdHtYeG6S1CKbQOh1zqylnQK6cV3z9k80yxAnFX9Y+a9+XysDhhfg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
+      "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
       "dev": true,
       "requires": {
         "async-foreach": "0.1.3",
         "chalk": "1.1.3",
         "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
+        "gaze": "1.1.3",
         "get-stdin": "4.0.1",
         "glob": "7.1.2",
         "in-publish": "2.0.0",
@@ -14474,7 +15724,7 @@
         "meow": "3.7.0",
         "mkdirp": "0.5.1",
         "nan": "2.10.0",
-        "node-gyp": "3.6.2",
+        "node-gyp": "3.7.0",
         "npmlog": "4.1.2",
         "request": "2.79.0",
         "sass-graph": "2.2.4",
@@ -14515,7 +15765,7 @@
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "which": "1.3.0"
           }
         },
@@ -14540,22 +15790,22 @@
           }
         },
         "gaze": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-          "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+          "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
           "dev": true,
           "requires": {
-            "globule": "1.2.0"
+            "globule": "1.2.1"
           }
         },
         "globule": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
-          "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+          "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
           "dev": true,
           "requires": {
             "glob": "7.1.2",
-            "lodash": "4.17.5",
+            "lodash": "4.17.10",
             "minimatch": "3.0.4"
           }
         },
@@ -14601,15 +15851,15 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         },
         "lru-cache": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -14663,12 +15913,6 @@
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
       }
@@ -14784,7 +16028,7 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
+        "are-we-there-yet": "1.1.5",
         "console-control-strings": "1.1.0",
         "gauge": "2.7.4",
         "set-blocking": "2.0.0"
@@ -15009,15 +16253,15 @@
       "integrity": "sha512-VwGbHIT89e+9XdGcb2gdPgKgYQGjRG5peyPNO982znlCSB/UIM9g7gF6JmHpaMHb8xvEScY7UGJ8GRz6GQVBRg=="
     },
     "office-ui-fabric-react": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.21.0.tgz",
-      "integrity": "sha512-9IBLK6JUWYvdCumKywjkSP7mf/MqTRorP1qXtb2c+w2fQJH4NkdBjanO0zr37c5VPwlqc0KvPf51E9t1NU7oTg==",
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.83.0.tgz",
+      "integrity": "sha512-PbmXcI8ayj5ER/eWiF9s6gddrmPaquinxyESgk2nqD+4imRo88ATi+guk798nt5D3Qaema7S4CnNf/gTCIl0rw==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.9",
-        "@uifabric/icons": "5.2.0",
-        "@uifabric/merge-styles": "5.15.2",
-        "@uifabric/styling": "5.25.0",
-        "@uifabric/utilities": "5.25.0",
+        "@microsoft/load-themed-styles": "1.7.53",
+        "@uifabric/icons": "5.7.1",
+        "@uifabric/merge-styles": "5.17.1",
+        "@uifabric/styling": "5.31.0",
+        "@uifabric/utilities": "5.33.0",
         "prop-types": "15.6.1",
         "tslib": "1.8.1"
       }
@@ -15030,12 +16274,6 @@
       "requires": {
         "ee-first": "1.1.1"
       }
-    },
-    "on-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
-      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -15154,12 +16392,14 @@
       "dev": true
     },
     "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
       }
     },
     "os-shim": {
@@ -15182,6 +16422,21 @@
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
+      }
+    },
+    "p-cancelable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+      "dev": true
+    },
+    "p-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-1.0.0.tgz",
+      "integrity": "sha1-Yp0xcVAgnI/VCLoTdxPvS7kg6ds=",
+      "dev": true,
+      "requires": {
+        "p-map": "1.2.0"
       }
     },
     "p-finally": {
@@ -15422,12 +16677,6 @@
         "pinkie-promise": "2.0.1"
       }
     },
-    "pause": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
-      "integrity": "sha1-68ikqGGf8LioGsFRPDQ0/0af23Q=",
-      "dev": true
-    },
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -15475,7 +16724,7 @@
       "dev": true,
       "requires": {
         "es6-promise": "4.1.1",
-        "extract-zip": "1.6.6",
+        "extract-zip": "1.6.7",
         "fs-extra": "1.0.0",
         "hasha": "2.2.0",
         "kew": "0.7.0",
@@ -15598,7 +16847,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.3",
+        "js-base64": "2.4.5",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -15693,13 +16942,12 @@
       }
     },
     "postcss-filter-plugins": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
-      "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
+      "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "uniqid": "4.1.1"
+        "postcss": "5.2.18"
       }
     },
     "postcss-load-config": {
@@ -15773,8 +17021,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000830",
-            "electron-to-chromium": "1.3.42"
+            "caniuse-db": "1.0.30000851",
+            "electron-to-chromium": "1.3.48"
           }
         }
       }
@@ -15848,7 +17096,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.21"
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15861,9 +17109,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-          "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -15878,12 +17126,12 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+          "version": "6.0.22",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.0",
+            "chalk": "2.4.1",
             "source-map": "0.6.1",
             "supports-color": "5.4.0"
           }
@@ -15912,7 +17160,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.21"
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15925,9 +17173,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-          "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -15942,12 +17190,12 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+          "version": "6.0.22",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.0",
+            "chalk": "2.4.1",
             "source-map": "0.6.1",
             "supports-color": "5.4.0"
           }
@@ -15976,7 +17224,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.21"
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15989,9 +17237,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-          "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -16006,12 +17254,12 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+          "version": "6.0.22",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.0",
+            "chalk": "2.4.1",
             "source-map": "0.6.1",
             "supports-color": "5.4.0"
           }
@@ -16040,7 +17288,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.21"
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -16053,9 +17301,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-          "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -16070,12 +17318,12 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+          "version": "6.0.22",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.0",
+            "chalk": "2.4.1",
             "source-map": "0.6.1",
             "supports-color": "5.4.0"
           }
@@ -16228,15 +17476,21 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
-      "integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1",
+        "ansi-regex": "3.0.0",
         "ansi-styles": "3.2.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -16297,13 +17551,13 @@
       }
     },
     "proxy-addr": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "dev": true,
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.4.0"
+        "ipaddr.js": "1.6.0"
       }
     },
     "prr": {
@@ -16357,6 +17611,14 @@
       "requires": {
         "object-assign": "4.1.1",
         "strict-uri-encode": "1.1.0"
+      },
+      "dependencies": {
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+          "dev": true
+        }
       }
     },
     "querystring": {
@@ -16386,6 +17648,12 @@
       "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
       "dev": true
     },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
+      "dev": true
+    },
     "randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
@@ -16395,12 +17663,6 @@
         "discontinuous-range": "1.0.0",
         "ret": "0.1.15"
       }
-    },
-    "random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=",
-      "dev": true
     },
     "randomatic": {
       "version": "1.1.7",
@@ -16449,46 +17711,25 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
       },
       "dependencies": {
-        "depd": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "depd": "1.1.1",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.3",
-            "statuses": "1.5.0"
+            "safer-buffer": "2.1.2"
           }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-          "dev": true
         }
       }
     },
@@ -16755,9 +17996,9 @@
       }
     },
     "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -16791,7 +18032,7 @@
       "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
+        "regenerate": "1.4.0",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       }
@@ -17037,16 +18278,6 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
-    "response-time": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
-      "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
-      "dev": true,
-      "requires": {
-        "depd": "1.1.2",
-        "on-headers": "1.0.1"
-      }
-    },
     "restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
@@ -17091,12 +18322,6 @@
         "inherits": "2.0.3"
       }
     },
-    "rndm": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
-      "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w=",
-      "dev": true
-    },
     "rst-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -17106,6 +18331,12 @@
         "lodash.flattendeep": "4.4.0",
         "nearley": "2.13.0"
       }
+    },
+    "rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true
     },
     "run-async": {
       "version": "2.3.0",
@@ -17149,36 +18380,29 @@
       "dev": true
     },
     "sane": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
-      "integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+      "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
+        "anymatch": "2.0.0",
+        "capture-exit": "1.2.0",
         "exec-sh": "0.2.1",
-        "fb-watchman": "1.9.2",
-        "minimatch": "3.0.4",
+        "fb-watchman": "2.0.0",
+        "micromatch": "3.1.10",
         "minimist": "1.2.0",
         "walker": "1.0.7",
-        "watch": "0.10.0"
+        "watch": "0.18.0"
       },
       "dependencies": {
-        "bser": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
-          "integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "node-int64": "0.4.0"
-          }
-        },
-        "fb-watchman": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
-          "integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
-          "dev": true,
-          "requires": {
-            "bser": "1.0.2"
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
           }
         }
       }
@@ -17190,7 +18414,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "scss-tokenizer": "0.2.3",
         "yargs": "7.1.0"
       },
@@ -17213,9 +18437,24 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
           "dev": true
         },
         "yargs": {
@@ -17238,6 +18477,15 @@
             "y18n": "3.2.1",
             "yargs-parser": "5.0.0"
           }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
         }
       }
     },
@@ -17256,18 +18504,13 @@
         "ajv": "5.2.5"
       }
     },
-    "scrollreveal": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/scrollreveal/-/scrollreveal-3.3.6.tgz",
-      "integrity": "sha512-5HiAtVqwffX18w/kqXkD+S54A0MoE4xLAwQcszEYGuy+EsRUoHsw1BhFpxGCcbTXIy5HMtj/qmLDbpQ+J3llig=="
-    },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.4.3",
+        "js-base64": "2.4.5",
         "source-map": "0.4.4"
       },
       "dependencies": {
@@ -17289,76 +18532,36 @@
       "dev": true
     },
     "send": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
-      "integrity": "sha1-ObBDiz9RC+Xcb2Z6EfcWiTaM3u8=",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "dev": true,
       "requires": {
-        "debug": "2.2.0",
+        "debug": "2.6.9",
         "depd": "1.1.2",
         "destroy": "1.0.4",
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
-        "etag": "1.7.0",
-        "fresh": "0.3.0",
-        "http-errors": "1.5.1",
-        "mime": "1.3.4",
-        "ms": "0.7.2",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.3",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-              "dev": true
-            }
-          }
-        },
-        "http-errors": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-          "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.2",
-            "statuses": "1.3.1"
-          }
-        },
         "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-          "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg=",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
           "dev": true
         },
         "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
       }
@@ -17369,94 +18572,49 @@
       "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
       "dev": true
     },
-    "serve-favicon": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz",
-      "integrity": "sha1-3UGeJo3gEqtysxnTN/IQUBP5OB8=",
-      "dev": true,
-      "requires": {
-        "etag": "1.7.0",
-        "fresh": "0.3.0",
-        "ms": "0.7.2",
-        "parseurl": "1.3.2"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        }
-      }
-    },
     "serve-index": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
-      "integrity": "sha1-egV/xu4o3GP2RWbl+lexEahq7NI=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "1.2.13",
-        "batch": "0.5.3",
-        "debug": "2.2.0",
+        "accepts": "1.3.5",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
         "escape-html": "1.0.3",
-        "http-errors": "1.3.1",
+        "http-errors": "1.6.3",
         "mime-types": "2.1.18",
         "parseurl": "1.3.2"
       },
       "dependencies": {
         "accepts": {
-          "version": "1.2.13",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-          "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+          "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "dev": true,
           "requires": {
             "mime-types": "2.1.18",
-            "negotiator": "0.5.3"
+            "negotiator": "0.6.1"
           }
         },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "http-errors": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "statuses": "1.5.0"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "negotiator": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-          "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g=",
+        "batch": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+          "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
           "dev": true
         }
       }
     },
     "serve-static": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz",
-      "integrity": "sha1-LPmIm9RDWjIMw2iVyapXvWYuasc=",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.14.2"
+        "send": "0.16.2"
       }
     },
     "set-blocking": {
@@ -17960,7 +19118,7 @@
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "os-shim": "0.1.3"
       }
     },
@@ -18012,6 +19170,15 @@
       "dev": true,
       "requires": {
         "extend-shallow": "3.0.2"
+      }
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "dev": true,
+      "requires": {
+        "through2": "2.0.3"
       }
     },
     "sprintf-js": {
@@ -18173,19 +19340,10 @@
       "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
       "dev": true
     },
-    "stream-counter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
-      "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "1.1.14"
-      }
-    },
     "stream-http": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
-      "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
@@ -18234,9 +19392,9 @@
       "dev": true
     },
     "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
       "dev": true
     },
     "string-hash": {
@@ -18246,12 +19404,30 @@
       "dev": true
     },
     "string-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-      "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+      "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
-        "strip-ansi": "3.0.1"
+        "astral-regex": "1.0.0",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
       }
     },
     "string-width": {
@@ -18317,6 +19493,12 @@
         }
       }
     },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
+      "dev": true
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -18353,13 +19535,13 @@
       }
     },
     "superagent": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
-      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
+        "cookiejar": "2.1.2",
         "debug": "3.1.0",
         "extend": "3.0.1",
         "form-data": "2.3.2",
@@ -18491,7 +19673,7 @@
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.4",
+        "duplexify": "3.6.0",
         "fork-stream": "0.0.4",
         "merge-stream": "1.0.1",
         "through2": "2.0.3"
@@ -18522,10 +19704,28 @@
       "integrity": "sha1-ZUhjk+4fK7A5pgy7oFsLaL2VAdI=",
       "dev": true
     },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
+      "requires": {
+        "thenify": "3.3.0"
+      }
+    },
     "throat": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-      "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
     "throttleit": {
@@ -18614,6 +19814,16 @@
       "dev": true,
       "requires": {
         "setimmediate": "1.0.5"
+      }
+    },
+    "timers-ext": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.5.tgz",
+      "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.45",
+        "next-tick": "1.0.0"
       }
     },
     "tiny-lr": {
@@ -19482,21 +20692,60 @@
       "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
     },
     "tslint": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.6.0.tgz",
-      "integrity": "sha1-CIqmxgJmIzOGULKQCCirPt9Z9s8=",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
+      "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
-        "colors": "1.2.1",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.4.1",
         "commander": "2.15.1",
         "diff": "3.5.0",
         "glob": "7.1.2",
+        "js-yaml": "3.11.0",
         "minimatch": "3.0.4",
         "resolve": "1.7.1",
         "semver": "5.3.0",
         "tslib": "1.8.1",
-        "tsutils": "2.26.1"
+        "tsutils": "2.27.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "tslint-microsoft-contrib": {
@@ -19505,19 +20754,13 @@
       "integrity": "sha512-5AnfTGlfpUzpRHLmoojPBKFTTmbjnwgdaTHMdllausa4GBPya5u36i9ddrTX4PhetGZvd4JUYIpAmgHqVnsctg==",
       "dev": true,
       "requires": {
-        "tsutils": "2.26.1"
+        "tsutils": "2.27.1"
       }
     },
-    "tsscmp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
-      "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc=",
-      "dev": true
-    },
     "tsutils": {
-      "version": "2.26.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.1.tgz",
-      "integrity": "sha512-bnm9bcjOqOr1UljleL94wVCDlpa6KjfGaTkefeLch4GRafgDkROxPizbB/FxTEdI++5JqhxczRy/Qub0syNqZA==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.1.tgz",
+      "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
       "dev": true,
       "requires": {
         "tslib": "1.8.1"
@@ -19630,15 +20873,6 @@
         "webpack-sources": "1.1.0"
       }
     },
-    "uid-safe": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
-      "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
-      "dev": true,
-      "requires": {
-        "random-bytes": "1.0.0"
-      }
-    },
     "ultron": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
@@ -19697,15 +20931,6 @@
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
-    },
-    "uniqid": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
-      "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-      "dev": true,
-      "requires": {
-        "macaddress": "0.2.8"
-      }
     },
     "uniqs": {
       "version": "2.0.0",
@@ -19778,9 +21003,9 @@
       }
     },
     "upath": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
-      "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
       "dev": true
     },
     "upper-case": {
@@ -19790,18 +21015,18 @@
       "dev": true
     },
     "uri-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
-      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "2.1.1"
       },
       "dependencies": {
         "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
           "dev": true
         }
       }
@@ -19851,43 +21076,29 @@
       "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
+        "lru-cache": "4.1.3",
         "tmp": "0.0.33"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
             "yallist": "2.1.2"
           }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
         }
       }
     },
     "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.0.tgz",
+      "integrity": "sha512-5n12uMzKCjvB2HPFHnbQSjaqAa98L5iIXmHrZCLavuZVe0qe/SJGbDGWlpaHk5lnBkWRDO+dRu1/PgmUYKPPTw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        }
+        "inherits": "2.0.3"
       }
     },
     "util-deprecate": {
@@ -19979,12 +21190,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
       }
-    },
-    "vhost": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
-      "integrity": "sha1-L7HezUxGaqiLD5NBrzPcGv8keNU=",
-      "dev": true
     },
     "vinyl": {
       "version": "0.5.3",
@@ -20105,15 +21310,19 @@
       }
     },
     "watch": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
-      "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
-      "dev": true
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+      "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+      "dev": true,
+      "requires": {
+        "exec-sh": "0.2.1",
+        "minimist": "1.2.0"
+      }
     },
     "watchpack": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
-      "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "dev": true,
       "requires": {
         "chokidar": "2.0.3",
@@ -20147,7 +21356,7 @@
             "normalize-path": "2.1.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0",
-            "upath": "1.0.4"
+            "upath": "1.1.0"
           }
         },
         "glob-parent": {
@@ -20193,7 +21402,7 @@
       "integrity": "sha512-OsHT3D0W0KmPPh60tC7asNnOmST6bKTiR90UyEdT9QYoaJ4OYN4Gg7WK1k3VxHK07ZoiYWPsKvlS/gAjwL/vRA==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
+        "acorn": "5.6.2",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "5.2.5",
         "ajv-keywords": "2.1.1",
@@ -20212,15 +21421,21 @@
         "supports-color": "4.5.0",
         "tapable": "0.2.8",
         "uglifyjs-webpack-plugin": "0.4.6",
-        "watchpack": "1.5.0",
+        "watchpack": "1.6.0",
         "webpack-sources": "1.1.0",
         "yargs": "8.0.2"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+          "version": "5.6.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
+          "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
+          "dev": true
+        },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
           "dev": true
         },
         "ansi-regex": {
@@ -20275,17 +21490,6 @@
             "parse-json": "2.2.0",
             "pify": "2.3.0",
             "strip-bom": "3.0.0"
-          }
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
           }
         },
         "path-type": {
@@ -20360,12 +21564,6 @@
             "has-flag": "2.0.0"
           }
         },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
-        },
         "yargs": {
           "version": "8.0.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
@@ -20385,15 +21583,6 @@
             "which-module": "2.0.0",
             "y18n": "3.2.1",
             "yargs-parser": "7.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
           }
         }
       }
@@ -20455,9 +21644,9 @@
       },
       "dependencies": {
         "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
           "dev": true
         },
         "clone-stats": {
@@ -20493,7 +21682,7 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "2.1.2",
+            "clone": "2.1.1",
             "clone-buffer": "1.0.0",
             "clone-stats": "1.0.0",
             "cloneable-readable": "1.1.2",
@@ -20509,7 +21698,7 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.11",
+        "http-parser-js": "0.4.13",
         "websocket-extensions": "0.1.3"
       }
     },
@@ -20572,15 +21761,15 @@
       }
     },
     "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"
@@ -20704,9 +21893,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
@@ -20746,6 +21935,15 @@
             "wrap-ansi": "2.1.0"
           }
         },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
         "window-size": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
@@ -20773,18 +21971,18 @@
       }
     },
     "yargs-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "4.1.0"
       },
       "dependencies": {
         "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         }
       }

--- a/samples/react-jest-testing/package.json
+++ b/samples/react-jest-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jest-testing",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "engines": {
     "node": ">=0.10.0"
@@ -15,32 +15,33 @@
     "react-dom": "15.6.2",
     "@types/react": "15.6.6",
     "@types/react-dom": "15.5.6",
-    "@microsoft/sp-core-library": "~1.4.1",
-    "@microsoft/sp-webpart-base": "~1.4.1",
-    "@microsoft/sp-lodash-subset": "~1.4.1",
-    "@microsoft/sp-office-ui-fabric-core": "~1.4.1",
-    "@types/webpack-env": ">=1.12.1 <1.14.0",
-    "@pnp/common": "1.0.4",
-    "@pnp/sp": "1.0.4",
-    "@pnp/odata": "1.0.4",
-    "@pnp/logging": "1.0.4"
+    "@microsoft/sp-core-library": "1.5.0",
+    "@microsoft/sp-webpart-base": "1.5.0",
+    "@microsoft/sp-lodash-subset": "1.5.0",
+    "@microsoft/sp-office-ui-fabric-core": "1.5.0",
+    "@types/webpack-env": "1.13.1",
+    "@types/es6-promise": "0.0.33",
+    "@pnp/common": "1.1.1",
+    "@pnp/sp": "1.1.1",
+    "@pnp/odata": "1.1.1",
+    "@pnp/logging": "1.1.1"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "~1.4.1",
-    "@microsoft/sp-module-interfaces": "~1.4.1",
-    "@microsoft/sp-webpart-workbench": "~1.4.1",
+    "@microsoft/sp-build-web": "1.5.0",
+    "@microsoft/sp-module-interfaces": "1.5.0",
+    "@microsoft/sp-webpart-workbench": "1.5.0",
     "gulp": "~3.9.1",
-    "@types/chai": ">=3.4.34 <3.6.0",
-    "@types/mocha": ">=2.2.33 <2.6.0",
+    "@types/chai": "3.4.34",
+    "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
     "@types/jest": "22.2.3",
     "jest": "22.4.3",
     "ts-jest": "22.4.5",
     "identity-obj-proxy": "3.0.0",
+    "react-test-renderer": "15.6.2",
     "enzyme": "3.3.0",
     "@types/enzyme": "3.1.10",
     "enzyme-adapter-react-15": "1.0.5",
-    "react-test-renderer": "15.6.2",
     "@types/sinon": "4.3.1",
     "sinon": "5.0.7",
     "jest-junit": "3.7.0"
@@ -57,7 +58,6 @@
     "testMatch": [
       "**/src/**/*.test.+(ts|tsx|js)"
     ],
-    "mapCoverage": true,
     "collectCoverage": true,
     "coverageReporters": [
       "json",

--- a/samples/react-jest-testing/src/webparts/iceCreamShop/IceCreamShopWebPart.manifest.json
+++ b/samples/react-jest-testing/src/webparts/iceCreamShop/IceCreamShopWebPart.manifest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://dev.office.com/json-schemas/spfx/client-side-web-part-manifest.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/spfx/client-side-web-part-manifest.schema.json",
   "id": "d67c5975-ba3e-49ec-9a23-245c15ea3cda",
   "alias": "IceCreamShopWebPart",
   "componentType": "WebPart",

--- a/samples/react-jest-testing/src/webparts/iceCreamShop/iceCreamProviders/IceCreamPnPJsProvider.ts
+++ b/samples/react-jest-testing/src/webparts/iceCreamShop/iceCreamProviders/IceCreamPnPJsProvider.ts
@@ -12,7 +12,7 @@ export class IceCreamPnPJsProvider implements IIceCreamProvider {
 
     public getAll(): Promise<IceCream[]> {
 
-        return new Promise<IceCream[]>(async (resolve, reject) => {
+        return new Promise<IceCream[]>((resolve, reject) => {
 
             const query: SearchQuery = {
                 RowLimit: 10,

--- a/samples/react-jest-testing/src/webparts/iceCreamShop/test/part1EnzymeBasics.test.ts
+++ b/samples/react-jest-testing/src/webparts/iceCreamShop/test/part1EnzymeBasics.test.ts
@@ -44,12 +44,15 @@ describe('Enzyme basics', () => {
 
   it('should has the correct title', () => {
 
+    // Arrange
     // define contains/like css selector
     let cssSelector: string = 'h1';
 
+    // Act
     // find the elemet using css selector
     const text = reactComponent.find(cssSelector).text();
 
+    // Assert
     expect(text).toBe("PnP Ice Cream Shop");  
   });
 });

--- a/samples/react-jest-testing/tsconfig.json
+++ b/samples/react-jest-testing/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "target": "es5",
     "forceConsistentCasingInFileNames": true,
-    "module": "commonjs",
+    "module": "esnext",
+    "moduleResolution": "node",
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/samples/react-jest-testing/vscode/launch.json
+++ b/samples/react-jest-testing/vscode/launch.json
@@ -1,0 +1,73 @@
+{
+  /**
+   * Install Chrome Debugger Extension for Visual Studio Code to debug your components with the
+   * Chrome browser: https://aka.ms/spfx-debugger-extensions
+   */
+  "version": "0.2.0",
+  "configurations": [
+    
+    {
+      "name": "Local workbench",
+      "type": "chrome",
+      "request": "launch",
+      "url": "https://localhost:4321/temp/workbench.html",
+      "webRoot": "${workspaceRoot}",
+      "sourceMaps": true,
+      "sourceMapPathOverrides": {
+        "webpack:///../../../src/*": "${webRoot}/src/*",
+        "webpack:///../../../../src/*": "${webRoot}/src/*",
+        "webpack:///../../../../../src/*": "${webRoot}/src/*"
+      },
+      "runtimeArgs": [
+        "--remote-debugging-port=9222"
+      ]
+    },
+    {
+      "name": "Hosted workbench",
+      "type": "chrome",
+      "request": "launch",
+      "url": "https://enter-your-SharePoint-site/_layouts/workbench.aspx",
+      "webRoot": "${workspaceRoot}",
+      "sourceMaps": true,
+      "sourceMapPathOverrides": {
+        "webpack:///../../../src/*": "${webRoot}/src/*",
+        "webpack:///../../../../src/*": "${webRoot}/src/*",
+        "webpack:///../../../../../src/*": "${webRoot}/src/*"
+      },
+      "runtimeArgs": [
+        "--remote-debugging-port=9222",
+        "-incognito"
+      ]
+    },
+    //https://github.com/Microsoft/vscode-recipes/tree/master/debugging-jest-tests
+    //https://github.com/facebook/jest/issues/1652
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest All",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "args": ["--runInBand"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Watch", 
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "args": ["--runInBand","--watch"], // jest --watch #runs jest -o by default
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      //https://facebook.github.io/jest/docs/en/cli.html
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Watch All",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "args": ["--runInBand","--watchAll"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                             |
| New feature?    | yes                             |
| New sample?     | no                    |
| Related issues? | fixes #X, partially #Y, mentioned in #Z |

## What's in this Pull Request?

- React Jest Testing updated to SPFx 1.5.0
- PnPJs updated to 1.1.1
- Missing launch.json configuration added
- Few small cosmetic fixes 
- Jest mapCoverage configuration option removed since deprecated

Please refer the the README file for more information or let me know if any issues.
