### PR TITLE
Private constructor in singleton

### DIFF
--- a/samples/react-designpatterns-typescript/Singleton/src/webparts/singleton/components/ConfigurationManager.ts
+++ b/samples/react-designpatterns-typescript/Singleton/src/webparts/singleton/components/ConfigurationManager.ts
@@ -1,9 +1,11 @@
 class ConfigurationManager {
     private static instance: ConfigurationManager;
-    public constructor() {
+  
+    private constructor() {
         // do something construct...
     }
-    static getInstance(): ConfigurationManager {
+  
+    public static getInstance(): ConfigurationManager {
         if (!ConfigurationManager.instance) {
             ConfigurationManager.instance = new ConfigurationManager();
             // ... any one time initialization goes here ...
@@ -12,15 +14,15 @@ class ConfigurationManager {
     }
 
     // excercise for the reader to get data from an external data source.
-    numberOfItemsPerPage(): number {
+    public numberOfItemsPerPage(): number {
         return 10;
     }
 
-    maxNumberOfConnections(): number {
+    public maxNumberOfConnections(): number {
         return 10;
     }
 
-    restTimeout(): number {
+    public restTimeout(): number {
         return 1000;
     }
 }


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New feature?    | no                             |
| New sample?     | no                             |

## What's in this Pull Request?

Updated the `public` constructor to `private` in singleton pattern. This prevents you from creating a new class instance outside the `ConfigurationManager`.
