### PR TITLE
Private constructor in singleton

### DIFF
--- a/samples/react-designpatterns-typescript/Singleton/src/webparts/singleton/components/ConfigurationManager.ts
+++ b/samples/react-designpatterns-typescript/Singleton/src/webparts/singleton/components/ConfigurationManager.ts
@@ -1,9 +1,11 @@
 class ConfigurationManager {
     private static instance: ConfigurationManager;
-    public constructor() {
+  
+    private constructor() {
         // do something construct...
     }
-    static getInstance(): ConfigurationManager {
+  
+    public static getInstance(): ConfigurationManager {
         if (!ConfigurationManager.instance) {
             ConfigurationManager.instance = new ConfigurationManager();
             // ... any one time initialization goes here ...
@@ -12,15 +14,15 @@ class ConfigurationManager {
     }
 
     // excercise for the reader to get data from an external data source.
-    numberOfItemsPerPage(): number {
+    public numberOfItemsPerPage(): number {
         return 10;
     }
 
-    maxNumberOfConnections(): number {
+    public maxNumberOfConnections(): number {
         return 10;
     }
 
-    restTimeout(): number {
+    public restTimeout(): number {
         return 1000;
     }
 }


### PR DESCRIPTION
Updated the `public` constructor to `private` in singleton pattern. This prevents you from creating a new class instance outside the `ConfigurationManager`.

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no - yes?                               |
| New feature?    | no - yes?                               |
| New sample?     | no - yes?                               |
| Related issues? | fixes #X, partially #Y, mentioned in #Z |

## What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_

## Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to `dev` branch. Released documents are in `master` branch.*
> 
> _(DELETE THIS PARAGRAPH AFTER READING)_
