### PR TITLE
improving new issue template so people mention samples authors and they get notified

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,6 +16,12 @@
 > 
 > _(DELETE THIS PARAGRAPH AFTER READING)_
 
+## Authors
+
+> Because of the way this repository is setup, samples authors do not get a notification when you create an issue. *It makes it less likely for you to get your issue resolved or to get help*. For the section above **@mention any author of the sample**. Authors' github handle can be found on the main sample documentation page, under the "solution" section. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
+> 
+> _(DELETE THIS PARAGRAPH AFTER READING)_
+
 ## Expected or Desired Behavior
 
 > _If you are reporting a bug, please describe the expected behavior. If you are suggesting an enhancement please describe thoroughly the enhancement, how it can be achieved, and expected benefit._


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New feature?    | yes                               |
| New sample?     | no                               |
| Related issues? | partially #385  |

## What's in this Pull Request?
This PR adds a new section to the GitHub issue template to suggest issue authors to mention samples authors. This way sample authors will get notified and issue authors are more likely to get an answer/fix.