### PR TITLE
Bug fix (React-File-Upload): Change in library selection will take affect immediately without requiring page refresh

### DIFF
--- a/samples/react-file-upload/src/webparts/fileUpload/components/FileUpload.tsx
+++ b/samples/react-file-upload/src/webparts/fileUpload/components/FileUpload.tsx
@@ -46,11 +46,11 @@ export default class FileUpload extends React.Component<IFileUploadProps, {}> {
       processing: function (file, xhr) {
         
         if(_fileUploadTo=="DocumentLibrary")
-          myDropzone.options.url = `${_context.pageContext.web.absoluteUrl}/_api/web/Lists/getById('${_listName}')/rootfolder/files/add(overwrite=true,url='${file.name}')`;          
+          myDropzone.options.url = `${_context.pageContext.web.absoluteUrl}/_api/web/Lists/getById('${_parent.props.listName}')/rootfolder/files/add(overwrite=true,url='${file.name}')`;          
         else
         {          
           if(_itemId)
-            myDropzone.options.url = `${_context.pageContext.web.absoluteUrl}/_api/web/lists/getById('${_listName}')/items(${_itemId})/AttachmentFiles/add(FileName='${file.name}')`;
+            myDropzone.options.url = `${_context.pageContext.web.absoluteUrl}/_api/web/lists/getById('${_parent.props.listName}')/items(${_itemId})/AttachmentFiles/add(FileName='${file.name}')`;
           else
             alert('Item not found or query string value is null!')
         }
@@ -76,7 +76,7 @@ export default class FileUpload extends React.Component<IFileUploadProps, {}> {
     };
     return (
       <DropzoneComponent eventHandlers={eventHandlers} djsConfig={djsConfig} config={componentConfig}>
-        <div className="dz-message icon ion-upload">Drop files here or click to upload.</div>
+        <div className="dz-message icon ion-upload">Drop files here or click to upload.</div>  
       </DropzoneComponent>
     );
   }


### PR DESCRIPTION
In the 'React-File-Upload' web part, any change to listname property in the FileUpload component was not getting picked up by the processing event handler method in DropZone component (child of FileUpload). User had to refresh the page to have the property change affect the upload form. This has been fixed by making sure the eventhandlers on dropzone component used the parent FileUpload component property for listname.

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                              |
| New feature?    | no                              |
| New sample?     | no                             |
| Related issues? |mentioned in #647  |

## What's in this Pull Request?

Change to couple of references to fix the bug described above.



