### PR TITLE
react-search-refiners: mapToIcon fix if filename has query string

### DIFF
--- a/samples/react-search-refiners/src/services/SearchService/SearchService.ts
+++ b/samples/react-search-refiners/src/services/SearchService/SearchService.ts
@@ -310,7 +310,11 @@ class SearchService implements ISearchService {
         const webAbsoluteUrl = this._context.pageContext.web.absoluteUrl;
         
         try {
-            const encodedFileName = filename ? filename.replace(/['']/g, '') : '';
+            let encodedFileName = filename ? filename.replace(/['']/g, '') : '';
+            const queryStringIndex = encodedFileName.indexOf('?');
+            if (queryStringIndex !== -1) { // filename with query string leads to 400 error.
+                encodedFileName = encodedFileName.slice(0, queryStringIndex);
+            }
             const iconFileName = await this._localPnPSetup.web.mapToIcon(encodedFileName, 1);
             const iconUrl = webAbsoluteUrl + '/_layouts/15/images/' + iconFileName;
 


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | no |

## What's in this Pull Request?

The PR contains a fix for React Search Refiners web part: `mapToIcon` returned Bad Request if `filename` has a query string. It could happen for quick links and other urls.
