### PR TITLE
[react-list-form] Bug fix in DateFormField.tsx

### DIFF
--- a/samples/react-list-form/src/webparts/listForm/components/formFields/DateFormField.tsx
+++ b/samples/react-list-form/src/webparts/listForm/components/formFields/DateFormField.tsx
@@ -11,8 +11,8 @@ export interface IDateFormFieldProps extends IDatePickerProps {
 
 
 export default class DateFormField extends React.Component<IDateFormFieldProps> {
-  public constructor() {
-    super();
+  constructor(props) {
+    super(props);
   }
 
   public render() {


### PR DESCRIPTION
passing props to constructor to prevent transpile time errors

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                              |
| Related issues? |  |

## What's in this Pull Request?

Passing props to constructor. Arguments expected in constructor but received none errors during transpiling.