### PR TITLE
React Content Query: Lookup column additional fields fix

### DIFF
--- a/samples/react-content-query-webpart/src/common/services/ContentQueryService.ts
+++ b/samples/react-content-query-webpart/src/common/services/ContentQueryService.ts
@@ -565,13 +565,14 @@ export class ContentQueryService implements IContentQueryService {
 
         for(let result of results) {
             let normalizedResult: any = {};
+            let formattedCharsRegex = /_x00(20|3a)_/gi;
 
             for(let viewField of viewFields) {
-                let spacesFormattedName = viewField.replace(new RegExp("_x0020_", "g"), "_x005f_x0020_x005f_");
+                let formattedName = viewField.replace(formattedCharsRegex, "_x005f_x00$1_x005f_");
 
                 normalizedResult[viewField] = {
-                    textValue: result.FieldValuesAsText[spacesFormattedName],
-                    htmlValue: result.FieldValuesAsHtml[spacesFormattedName],
+                    textValue: result.FieldValuesAsText[formattedName],
+                    htmlValue: result.FieldValuesAsHtml[formattedName],
                     rawValue: result[viewField] || result[viewField + 'Id']
                 };
             }


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes |
| New feature?    | no |
| New sample?     | no |
| Related issues? | fixes #805 |

## What's in this Pull Request?

Fix: React Content Query web part does not display values from lookup column additional fields.

- Updated ContentQueryService.normalizeQueryResults to handle the encoded ":" in the column names of lookup column additional fields.

The existing function already handled spaces by replacing _x0020_ in column names with _x005f_x0020_x005f_ to determine the used in the result set. This update does the same with _x003A_.
