### PR TITLE
Font Color to Background Color

### DIFF
--- a/samples/section-backgrounds/src/webparts/basicPlainSectionBackgroundExample/BasicPlainSectionBackgroundExampleWebPart.ts
+++ b/samples/section-backgrounds/src/webparts/basicPlainSectionBackgroundExample/BasicPlainSectionBackgroundExampleWebPart.ts
@@ -11,7 +11,7 @@ export default class BasicPlainSectionBackgroundExampleWebPart extends BaseClien
     // See https://github.com/OfficeDev/office-ui-fabric-react/wiki/Theming
     const semanticColors: Readonly<ISemanticColors> | undefined = this._themeVariant && this._themeVariant.semanticColors;
 
-    const style: string = ` style="color:${semanticColors.bodyText}"`;
+    const style: string = ` style="background-color:${semanticColors.bodyBackground}"`;
     this.domElement.innerHTML = `<p${'' || (this._themeProvider && style)}>${this._textContent}</p>`;
   }
 

--- a/samples/section-backgrounds/src/webparts/basicReactSectionBackgroundExample/components/BasicSectionBackgroundExample.tsx
+++ b/samples/section-backgrounds/src/webparts/basicReactSectionBackgroundExample/components/BasicSectionBackgroundExample.tsx
@@ -11,7 +11,7 @@ export default class BasicSectionBackgroundExample extends React.Component<IBasi
     const { semanticColors }: IReadonlyTheme = this.props.themeVariant;
 
     return (
-      <div style={{color: semanticColors.bodyText}}>
+      <div style={{backgroundColor: semanticColors.bodyBackground}}>
         <p>This React web part has support for section backgrounds and will inherit its background from the section</p>
       </div>
     );


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                              |
| New feature?    | no                               |
| New sample?     | no                              |
| Related issues? | none |

## What's in this Pull Request?

Adjusted section background samples to use the `bodyBackground` to set the background rather than `bodyText` to set the font color. This is more in line with the goal of the samples (taking advantage of the section background).