### PR TITLE
Finalized localization issues

### DIFF
--- a/samples/react-calendar/src/controls/EventRecurrenceInfoMonthly/EventRecurrenceInfoMonthly.tsx
+++ b/samples/react-calendar/src/controls/EventRecurrenceInfoMonthly/EventRecurrenceInfoMonthly.tsx
@@ -254,7 +254,7 @@ export class EventRecurrenceInfoMonthly extends React.Component<IEventRecurrence
    * @memberof EventRecurrenceInfoMonthly
    */
   private  onWeekOrderMonthChange(ev: React.FormEvent<HTMLDivElement>, item: IDropdownOption):void {
-    this.setState({selectedWeekOrderMonth: item.text});
+    this.setState({selectedWeekOrderMonth: item.key.toString()});
     this.applyRecurrence();
   }
 
@@ -472,7 +472,7 @@ export class EventRecurrenceInfoMonthly extends React.Component<IEventRecurrence
 
             </div>
             <div style={{ width: '100%', paddingTop: '10px' }}>
-              <Label>Patern</Label>
+              <Label>{ strings.patternLabel }</Label>
               <ChoiceGroup
                 selectedKey={this.state.selectPatern}
                 options={[
@@ -521,9 +521,9 @@ export class EventRecurrenceInfoMonthly extends React.Component<IEventRecurrence
                               disabled={!this.state.disableDayOfMonth}
                               options={[
                                 { key: 'first', text: strings.firstLabel },
-                                { key: 'second', text:strings.secondLabel},
+                                { key: 'second', text: strings.secondLabel},
                                 { key: 'third', text: strings.thirdLabel },
-                                { key: 'fourth', text:strings.fourthLabel },
+                                { key: 'fourth', text: strings.fourthLabel },
                                 { key: 'last', text: strings.lastLabel },
 
                               ]}

--- a/samples/react-calendar/src/controls/EventRecurrenceInfoYearly/EventRecurrenceInfoYearly.tsx
+++ b/samples/react-calendar/src/controls/EventRecurrenceInfoYearly/EventRecurrenceInfoYearly.tsx
@@ -207,7 +207,7 @@ export class EventRecurrenceInfoYearly extends React.Component<IEventRecurrenceI
    * @memberof EventRecurrenceInfoYearly
    */
   private onWeekOrderMonthChange(ev: React.FormEvent<HTMLDivElement>, item: IDropdownOption): void {
-    this.setState({ selectedWeekOrderMonth: item.text });
+    this.setState({ selectedWeekOrderMonth: item.key.toString() });
     this.applyRecurrence();
   }
 
@@ -232,7 +232,7 @@ export class EventRecurrenceInfoYearly extends React.Component<IEventRecurrenceI
    * @memberof EventRecurrenceInfoYearly
    */
   private onSelectedWeekDayChange(ev: React.FormEvent<HTMLDivElement>, item: IDropdownOption): void {
-    this.setState({ selectedWeekDay: item.text });
+    this.setState({ selectedWeekDay: item.key.toString() });
     this.applyRecurrence();
   }
 
@@ -526,7 +526,7 @@ export class EventRecurrenceInfoYearly extends React.Component<IEventRecurrenceI
                               ]}
                             />
                           </div>
-                          <Label styles={{ root: { display: 'inline-block', verticalAlign: 'top', width: '30px', paddingLeft: '10px' } }}>of</Label>
+                          <Label styles={{ root: { display: 'inline-block', verticalAlign: 'top', width: '30px', paddingLeft: '10px' } }}>{ strings.ofMonthLabel} </Label>
                           <div style={{ display: 'inline-block', verticalAlign: 'top', width: '100px', paddingLeft: '5px' }}>
                             <Dropdown
                               selectedKey={this.state.selectedYearlyByDayMonth}

--- a/samples/react-calendar/src/webparts/calendar/loc/en-us.js
+++ b/samples/react-calendar/src/webparts/calendar/loc/en-us.js
@@ -1,7 +1,7 @@
 define([], function () {
   return {
     WeeksOnLabel: "week(s) on",
-    PaternLabel: "Patern",
+    PaternLabel: "Pattern",
     OcurrencesLabel: "Ocurrences",
     dateRangeLabel: "Date Range",
     weekEndDay: "Weekend Day",
@@ -125,6 +125,7 @@ define([], function () {
     yearlyLabel: "Yearly",
     patternLabel: "Pattern",
     dateRangeLabel: "Date Range",
-    occurrencesLabel: "occurrences"
+    occurrencesLabel: "occurrences",
+    ofMonthLabel: "of"
   }
 });

--- a/samples/react-calendar/src/webparts/calendar/loc/mystrings.d.ts
+++ b/samples/react-calendar/src/webparts/calendar/loc/mystrings.d.ts
@@ -126,6 +126,7 @@ declare interface ICalendarWebPartStrings {
   patternLabel: string;
   dateRangeLabel: string;
   occurrencesLabel: string;
+  ofMonthLabel:string;
 
 }
 

--- a/samples/react-calendar/src/webparts/calendar/loc/sv-se.js
+++ b/samples/react-calendar/src/webparts/calendar/loc/sv-se.js
@@ -125,7 +125,8 @@ define([], function () {
       yearlyLabel: "Årligen",
       patternLabel: "Schema",
       dateRangeLabel: "Datumintervall",
-      occurrencesLabel: "tillfällen"
+      occurrencesLabel: "tillfällen",
+      ofMonthLabel: "i"
     }
   });
   


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?          | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | None |

## What's in this Pull Request?

Discovered a few issues as described below in my previous PR #946. 
* Missing translation of the Pattern label in the EventRecurrenceInfoMonthly control.
* Missing translation of the word "of" in the Event RecurrenceInfoYearly control, as in first Weekday _of_ August
* Dropdowns to select first, second, thirt, fourth or last in EventRecurrenceInfoMonthly and EventRecurrenceInfoYearly controls not working when text is different from corresponding key.
* Dropdown to select Weekday, monday, tuesday, wednesday, thursday, friday, saturday or sunday in EventRecurrenceInfoMonthly control not working when text is different from corresponding key.

