### PR TITLE
Fix npm install for react-rss-reader

### DIFF
--- a/samples/react-rss-reader/package-lock.json
+++ b/samples/react-rss-reader/package-lock.json
@@ -7404,7 +7404,7 @@
         "ansi-colors": "1.1.0",
         "connect": "3.6.6",
         "connect-livereload": "0.5.4",
-        "event-stream": "3.3.6",
+        "event-stream": "3.3.5",
         "fancy-log": "1.3.2",
         "send": "0.13.2",
         "serve-index": "1.9.1",
@@ -7428,13 +7428,12 @@
           "dev": true
         },
         "event-stream": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-          "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+          "version": "3.3.5",
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+          "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
           "dev": true,
           "requires": {
             "duplexer": "0.1.1",
-            "flatmap-stream": "0.1.0",
             "from": "0.1.7",
             "map-stream": "0.0.7",
             "pause-stream": "0.0.11",


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | fixes #793

## What's in this Pull Request?

Fix npm install command for react-rss-reader not finding packages event-stream@3.3.6 and flatmap-stream@0.1.0 .
flatmap-stream@0.1.0 is no longer a dependency of event-stream so I removed that altogether, as for event-stream I downgraded it from 3.3.6 to 3.3.5 being the previous malware-free version.
I preferred to edit package-lock.json manually than deleting the file and letting "npm install" rebuild it. Please let me know if that should be changed.

These 2 packages were removed from npm because they contained malware. More info at https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident
These there the 2 errors that "npm install" showed before this PR:
- ![image](https://user-images.githubusercontent.com/1153754/66984161-7e983b80-f0ba-11e9-93cb-61bf26b72a3c.png)
- ![image](https://user-images.githubusercontent.com/1153754/66984174-83f58600-f0ba-11e9-949b-4794c8315d72.png)

