### PR TITLE
Open extensions added to store metadata to saved mail

### DIFF
--- a/samples/react-outlook-copy2teams/README.md
+++ b/samples/react-outlook-copy2teams/README.md
@@ -1,4 +1,4 @@
-## outlook-2-teams-spfx
+## outlook-2-sp-spfx
 
 
 ## Summary
@@ -8,7 +8,7 @@ Furthermore it shows you how to retrieve a complete mail as a mimestream via Mic
 * Writing normal files smaller 4MB
 * Writing big files with an UploadSession when bigger than 4MB
 
-## outlook-2-teams-spfx in action
+## outlook-2-sp-spfx in action
 ![WebPartInAction](https://mmsharepoint.files.wordpress.com/2020/01/addin_overall.png)
 
 A detailed functionality and technical description can be found in the [author's blog series](https://mmsharepoint.wordpress.com/2020/01/11/an-outlook-add-in-with-sharepoint-framework-spfx-introduction/)
@@ -25,13 +25,14 @@ A detailed functionality and technical description can be found in the [author's
 
 Solution|Author(s)
 --------|---------
-outlook-2-teams-spfx| Markus Moeller ([@moeller2_0](http://www.twitter.com/moeller2_0))
+outlook-2-sp-spfx| Markus Moeller ([@moeller2_0](http://www.twitter.com/moeller2_0))
 
 ## Version history
 
 Version|Date|Comments
 -------|----|--------
-1.0|February 05, 2020|Initial release
+1.0|January 29, 2020|Initial release
+1.1|April 06, 2020|Open extensions to store metadata added
 
 ## Disclaimer
 
@@ -67,6 +68,5 @@ This Outlook Add-In shows the following capabilities on top of the SharePoint Fr
 * Use Microsoft Graph to retrieve joined Groups and Teams
 * Use Microsoft Graph to retrieve folders and subfolders for OneDrive or Teams/Group drives
 * Use Microsoft Graph to retrieve complete mail mimestream by given ID
-* Use Microsoft Graph to save normal or big files (in size bigger 4MB) with different concepts 
-
-<img src="https://telemetry.sharepointpnp.com/sp-dev-fx-webparts/samples/react-outlook-copy2teams" />
+* Use Microsoft Graph to save normal or big files (in size bigger 4MB) with different concepts
+* Optionally store metadata of save operation to copied mail with open extension (configure line 15 Outlook2SharePoint.tsx)

--- a/samples/react-outlook-copy2teams/config/package-solution.json
+++ b/samples/react-outlook-copy2teams/config/package-solution.json
@@ -26,8 +26,8 @@
       },
       {
         "resource": "Microsoft Graph",
-        "scope": "Mail.Read"
-      },
+        "scope": "Mail.ReadWrite"
+      },      
       {
         "resource": "Microsoft Graph",
         "scope": "Sites.ReadWrite.All"

--- a/samples/react-outlook-copy2teams/src/model/IFolder.ts
+++ b/samples/react-outlook-copy2teams/src/model/IFolder.ts
@@ -4,4 +4,5 @@ export interface IFolder {
   id: string;
   driveID: string;
   parentFolder: IFolder;
+  webUrl: string;
 }

--- a/samples/react-outlook-copy2teams/src/model/IMailMetadata.ts
+++ b/samples/react-outlook-copy2teams/src/model/IMailMetadata.ts
@@ -1,0 +1,6 @@
+export interface IMailMetadata {
+    extensionName: string;
+    saveDisplayName: string;
+    saveUrl: string;
+    savedDate: Date;
+}

--- a/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/Outlook2SharePointWebPart.ts
+++ b/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/Outlook2SharePointWebPart.ts
@@ -3,7 +3,7 @@ import * as ReactDom from 'react-dom';
 import { Version } from '@microsoft/sp-core-library';
 import {
   IPropertyPaneConfiguration,
-  PropertyPaneTextField
+  PropertyPaneToggle
 } from '@microsoft/sp-property-pane';
 import { BaseClientSideWebPart } from '@microsoft/sp-webpart-base';
 
@@ -13,22 +13,23 @@ import Outlook2SharePoint from './components/Outlook2SharePoint';
 import { IOutlook2SharePointProps } from './components/IOutlook2SharePointProps';
 
 export interface IOutlook2SharePointWebPartProps {
-  description: string;
+  
 }
 
 export default class Outlook2SharePointWebPart extends BaseClientSideWebPart <IOutlook2SharePointWebPartProps> {  
   public render(): void {
     let mail: IMail = null;    
     if (this.context.sdks.office) {
-      const item = this.context.sdks.office.context.mailbox.item;      
+      const item = this.context.sdks.office.context.mailbox.item;  
+      const itemId = this.context.sdks.office.context.mailbox.convertToRestId(item.itemId, 'v2.0');   
       if (item !== null) {
-        mail = { id: item.itemId,subject: item.subject };       
+        mail = { id: itemId, subject: item.subject };       
       }      
     }
     
     const element: React.ReactElement<IOutlook2SharePointProps> = React.createElement(
       Outlook2SharePoint,
-      {
+      {        
         msGraphClientFactory: this.context.msGraphClientFactory,
         mail: mail
       }
@@ -56,8 +57,8 @@ export default class Outlook2SharePointWebPart extends BaseClientSideWebPart <IO
             {
               groupName: strings.BasicGroupName,
               groupFields: [
-                PropertyPaneTextField('description', {
-                  label: strings.DescriptionFieldLabel
+                PropertyPaneToggle('saveMetadata', {
+                  label: strings.SaveMetadataFieldLabel
                 })
               ]
             }

--- a/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/components/IGroupsState.ts
+++ b/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/components/IGroupsState.ts
@@ -4,5 +4,6 @@ export interface IGroupsState {
   folders: IFolder[];
   grandParentFolder: IFolder;
   parentFolder: IFolder;
+  selectedGroupName: string;
   showSpinner: boolean;
 }

--- a/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/components/IOutlook2SharePointState.ts
+++ b/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/components/IOutlook2SharePointState.ts
@@ -1,7 +1,9 @@
 import GraphController from '../../../controller/GraphController';
+import { IMailMetadata } from '../../../model/IMailMetadata';
 
 export interface IOutlook2SharePointState {
   graphController: GraphController;
+  mailMetadata: IMailMetadata;
   showSuccess: boolean;
   showError: boolean;
   showOneDrive: boolean;

--- a/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/components/ITeamsState.ts
+++ b/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/components/ITeamsState.ts
@@ -4,5 +4,6 @@ export interface ITeamsState {
   folders: IFolder[];
   grandParentFolder: IFolder;
   parentFolder: IFolder;
+  selectedTeamName: string;
   showSpinner: boolean;
 }

--- a/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/components/OneDrive.tsx
+++ b/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/components/OneDrive.tsx
@@ -4,6 +4,7 @@ import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import Folder from './Folder';
 import styles from './Groups.module.scss';
+import * as strings from 'Outlook2SharePointWebPartStrings';
 import Breadcrumb from './controls/Breadcrumb';
 import { IOneDriveProps } from './IOneDriveProps';
 import { IOneDriveState } from './IOneDriveState';
@@ -49,14 +50,14 @@ export default class OneDrive extends React.Component<IOneDriveProps, IOneDriveS
         <div>
           <PrimaryButton
               className={styles.saveBtn}         
-              text="Save here"
+              text={strings.SaveLabel}
               onClick={this.saveMailTo}
               allowDisabledFocus={true}
             />
           { this.state.showSpinner && (
               <div className={styles.spinnerContainer}>
                 <Overlay >
-                  <Spinner size={ SpinnerSize.large } label='Processing request' />
+                  <Spinner size={ SpinnerSize.large } label={strings.SpinnerLabel} />
                 </Overlay>
               </div>
             ) }
@@ -103,7 +104,11 @@ export default class OneDrive extends React.Component<IOneDriveProps, IOneDriveS
         showSpinner: true
       };
     });
-    this.props.graphController.retrieveMimeMail(this.state.parentFolder.driveID, this.state.parentFolder.id, this.props.mail, this.saveMailCallback);    
+    this.props.graphController.retrieveMimeMail(this.state.parentFolder.driveID, this.state.parentFolder.id, this.props.mail, this.saveMailCallback)
+      .then((response: string) => {
+        const saveLocationDisplayName = `OneDrive ...> ${this.state.grandParentFolder.name} > ${this.state.parentFolder.name}`;
+        this.props.graphController.saveMailMetadata(this.props.mail.id, saveLocationDisplayName, this.state.parentFolder.webUrl, new Date());
+      });    
   }
 
   private saveMailCallback = (message: string) => {
@@ -113,10 +118,10 @@ export default class OneDrive extends React.Component<IOneDriveProps, IOneDriveS
       };
     });
     if (message.indexOf('Success') > -1) {
-      this.props.successCallback(message);
+      this.props.successCallback(strings.SuccessMessage);
     }
     else {
-      this.props.errorCallback(message);
+      this.props.errorCallback(strings.ErrorMessage);
     }
   }
 }

--- a/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/components/Outlook2SharePoint.module.scss
+++ b/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/components/Outlook2SharePoint.module.scss
@@ -14,4 +14,19 @@
     @include ms-fontSize-l;
     margin-left: 3px;
   }
+  .metadata {
+    margin-left: 6px;
+    margin-bottom: 8px;
+  }
+  .subMetadata {
+    margin-left: 6px;
+    a {
+      cursor: pointer;
+      text-decoration: none;
+      color: inherit;
+    }
+    a:hover {
+      @include ms-fontColor-themePrimary;
+    }
+  }
 }

--- a/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/components/Teams.tsx
+++ b/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/components/Teams.tsx
@@ -5,6 +5,7 @@ import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import Breadcrumb from './controls/Breadcrumb';
 import Folder from './Folder';
 import styles from './Groups.module.scss';
+import * as strings from 'Outlook2SharePointWebPartStrings';
 import { ITeamsProps } from './ITeamsProps';
 import { ITeamsState } from './ITeamsState';
 import { IFolder } from '../../../model/IFolder';
@@ -16,6 +17,7 @@ export default class Teams extends React.Component<ITeamsProps, ITeamsState> {
       folders: [],
       grandParentFolder: null,
       parentFolder: null,
+      selectedTeamName: '',
       showSpinner: false
     };    
   }
@@ -50,7 +52,7 @@ export default class Teams extends React.Component<ITeamsProps, ITeamsState> {
         <div>
           <PrimaryButton
               className={styles.saveBtn}         
-              text="Save here"
+              text={strings.SaveLabel}
               onClick={this.saveMailTo}
               disabled={this.state.parentFolder === null}
               allowDisabledFocus={true}
@@ -58,7 +60,7 @@ export default class Teams extends React.Component<ITeamsProps, ITeamsState> {
           { this.state.showSpinner && (
               <div className={styles.spinnerContainer}>
                 <Overlay >
-                  <Spinner size={ SpinnerSize.large } label='Processing request' />
+                  <Spinner size={ SpinnerSize.large } label={strings.SpinnerLabel} />
                 </Overlay>
               </div>
             ) }
@@ -77,20 +79,15 @@ export default class Teams extends React.Component<ITeamsProps, ITeamsState> {
     });
   }
 
-  private getGroupDrives = (group: IFolder) => {
-    let nextParent: IFolder = null;
-    this.state.folders.forEach((fldr) => {
-      if (fldr.id === group.id) {
-        nextParent = fldr;
-      }
-    });
+  private getGroupDrives = (group: IFolder) => {    
     this.props.graphController.getGroupDrives(group).then((folders) => {
       if (folders.length > 0) {
         this.setState((prevState: ITeamsState, props: ITeamsProps) => {
           return {
             folders: folders,
             grandParentFolder: null,
-            parentFolder: group
+            parentFolder: group,
+            selectedTeamName: group.name
           };
         });
       }
@@ -122,7 +119,6 @@ export default class Teams extends React.Component<ITeamsProps, ITeamsState> {
     }
   }
 
-  
   private showRoot = () => {
     this.getTeams();
   }
@@ -142,7 +138,11 @@ export default class Teams extends React.Component<ITeamsProps, ITeamsState> {
         showSpinner: true
       };
     });
-    this.props.graphController.retrieveMimeMail(this.state.parentFolder.driveID, this.state.parentFolder.id, this.props.mail, this.saveMailCallback);    
+    this.props.graphController.retrieveMimeMail(this.state.parentFolder.driveID, this.state.parentFolder.id, this.props.mail, this.saveMailCallback)
+      .then((response: string) => {
+        const saveLocationDisplayName = `${this.state.selectedTeamName} ...> ${this.state.grandParentFolder.name} > ${this.state.parentFolder.name}`;
+        this.props.graphController.saveMailMetadata(this.props.mail.id, saveLocationDisplayName, this.state.parentFolder.webUrl, new Date());
+      }); 
   }
 
   private saveMailCallback = (message: string) => {
@@ -152,10 +152,10 @@ export default class Teams extends React.Component<ITeamsProps, ITeamsState> {
       };
     });
     if (message.indexOf('Success') > -1) {
-      this.props.successCallback(message);
+      this.props.successCallback(strings.SuccessMessage);
     }
     else {
-      this.props.errorCallback(message);
+      this.props.errorCallback(strings.ErrorMessage);
     }
   }
 }

--- a/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/loc/en-us.js
+++ b/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/loc/en-us.js
@@ -1,7 +1,14 @@
 define([], function() {
   return {
-    "PropertyPaneDescription": "Description",
-    "BasicGroupName": "Group Name",
-    "DescriptionFieldLabel": "Description Field"
+    "PropertyPaneDescription": "Copy to OneDrive/Teams",
+    "BasicGroupName": "Configuration",
+    "SaveMetadataFieldLabel": "Save Metadata on copied mail",
+    "SaveInfo": "You already saved this mail",
+    "To": "to",
+    "On": "on",
+    "SaveLabel": "Save here",
+    "SpinnerLabel": "Processing request",
+    "SuccessMessage": "Success",
+    "ErrorMessage": "Error occured"
   }
 });

--- a/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/loc/mystrings.d.ts
+++ b/samples/react-outlook-copy2teams/src/webparts/outlook2SharePoint/loc/mystrings.d.ts
@@ -1,7 +1,14 @@
 declare interface IOutlook2SharePointWebPartStrings {
   PropertyPaneDescription: string;
   BasicGroupName: string;
-  DescriptionFieldLabel: string;
+  SaveMetadataFieldLabel: string;
+  SaveInfo: string;
+  To: string;
+  On: string;
+  SaveLabel: string;
+  SpinnerLabel: string;
+  SuccessMessage: string;
+  ErrorMessage: string;
 }
 
 declare module 'Outlook2SharePointWebPartStrings' {


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                                |
| New feature?    | yes                               |
| New sample?     | no                              |

## What's in this Pull Request?

Enforced by the discussion during my demo in the SPGx SIG call on 27-Feb I added the option to store as metadata when and where a mail was saved to eventually remind user upfront if a mailw as stored already. Using Microsoft Graph Open Extensions for that.
[See my blogpost on this](https://mmsharepoint.wordpress.com/2020/04/06/an-outlook-add-in-with-sharepoint-framework-spfx-store-custom-metadata-with-your-mail/) for detailed explanation
