### PR TITLE
committing changes to resolve issue 949

### DIFF
--- a/samples/react-kanban-board/config/package-solution.json
+++ b/samples/react-kanban-board/config/package-solution.json
@@ -5,6 +5,7 @@
     "id": "cccbd72b-7b89-4128-9348-0a4850ded8fd",
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
+    "skipFeatureDeployment": true,
     "isDomainIsolated": false
   },
   "paths": {

--- a/samples/react-kanban-board/gulpfile.js
+++ b/samples/react-kanban-board/gulpfile.js
@@ -1,7 +1,53 @@
 'use strict';
 
+
+
 const gulp = require('gulp');
 const build = require('@microsoft/sp-build-web');
 build.addSuppression(`Warning - [sass] The local CSS class 'ms-Grid' is not camelCase and will not be type-safe.`);
+
+// This section is inspired by Stefan Bauer's article at https://n8d.at/how-to-version-new-sharepoint-framework-projects/
+// Stefan rocks!
+let syncVersionsSubtask = build.subTask('version-sync', function (gulp, buildOptions, done) {
+    this.log('Synching versions');
+    
+    // import gulp utilits to write error messages
+    const gutil = require('gulp-util');
+    
+    // import file system utilities form nodeJS
+    const fs = require('fs');
+    
+    // read package.json
+    var pkgConfig = require('./package.json');
+    
+    // read configuration of web part solution file
+    var pkgSolution = require('./config/package-solution.json');
+    
+    // log old version
+    this.log('package-solution.json version:\t' + pkgSolution.solution.version);
+    
+    // Generate new MS compliant version number
+    var newVersionNumber = pkgConfig.version.split('-')[0] + '.0';
+    
+    if (pkgSolution.solution.version !== newVersionNumber) {
+    // assign newly generated version number to web part version
+    pkgSolution.solution.version = newVersionNumber;
+    
+    // log new version
+    this.log('New package-solution.json version:\t' + pkgSolution.solution.version);
+    
+    // write changed package-solution file
+    fs.writeFile('./config/package-solution.json', JSON.stringify(pkgSolution, null, 4));
+    }
+    else {
+    this.log('package-solution.json version is up-to-date');
+    }
+    
+    done();
+    }); 
+    let syncVersionTask = build.task('version-sync', syncVersionsSubtask);
+    build.rig.addPreBuildTask(syncVersionTask);
+
+
 
 build.initialize(gulp);

--- a/samples/react-kanban-board/package-lock.json
+++ b/samples/react-kanban-board/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-kanban-board",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/samples/react-kanban-board/package.json
+++ b/samples/react-kanban-board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-kanban-board",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "private": true,
   "engines": {
     "node": ">=0.10.0"

--- a/samples/react-kanban-board/src/webparts/kanbanBoard/KanbanBoardWebPart.manifest.json
+++ b/samples/react-kanban-board/src/webparts/kanbanBoard/KanbanBoardWebPart.manifest.json
@@ -12,7 +12,7 @@
   // Components that allow authors to embed arbitrary script code should set this to true.
   // https://support.office.com/en-us/article/Turn-scripting-capabilities-on-or-off-1f2c515f-5d7e-448a-9fd7-835da935584f
   "requiresCustomScript": false,
-  "supportedHosts": ["SharePointWebPart"],
+  "supportedHosts": ["SharePointWebPart", "TeamsTab"],
 
   "preconfiguredEntries": [{
     "groupId": "5c03119e-3074-46fd-976b-c60198311f70", // Other

--- a/samples/react-kanban-board/src/webparts/kanbanBoard/KanbanBoardWebPart.ts
+++ b/samples/react-kanban-board/src/webparts/kanbanBoard/KanbanBoardWebPart.ts
@@ -33,6 +33,8 @@ export default class KanbanBoardWebPart extends BaseClientSideWebPart<IKanbanBoa
 
   public render(): void {
     
+
+  
     const element: React.ReactElement<IKanbanBoardProps > = React.createElement(
       KanbanBoard,
       {
@@ -73,7 +75,8 @@ export default class KanbanBoardWebPart extends BaseClientSideWebPart<IKanbanBoa
   }
 
   protected onPropertyPaneConfigurationStart(){
-      sp.web.lists.filter("BaseTemplate eq 171").select("Title").get().then(res => {
+       // Use the list template ID to locate both the old style task lists (107) and newer task lists (171) 
+       sp.web.lists.filter("BaseTemplate eq 171 or BaseTemplate eq 107").select("Title").get().then(res => {
         this.properties.lists = res.map((val,index) => {
           return {
             key: val.Title,


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                                |
| New sample?     | no |
| Related issues? | fixes #949  |

## What's in this Pull Request?
Resolves the issue whereby the user (@Dips23) is able deploy Kanban web part to  aSharePoint page but not a in teams tab. Furthermore, the selected Kanban web part in  application catalogue produces a "failed to synced to teams" error.

**Summary of changes**

1. In package-solutions.json
Enabled tenant wide deployment
`"skipFeatureDeployment": true,`

2. In the KanbanBoardWebPart.mainfest.json
Changed supported hosts to  additionally, include Teams
`"supportedHosts": ["SharePointWebPart", "TeamsTab"],`

3. In KanbanBoardWebPart.ts 
Changed onPropertyPaneConfigurationStart method to locate Use the list template ID to locate both the old style task lists (107) or newer task lists (171) . This change does not impact the issue but ensures both types of task list, can be made available to the web part.
`sp.web.lists.filter("BaseTemplate eq 171 or BaseTemplate eq 107").select("Title").get().then(res => {`


![Successfully synced to Teams](https://user-images.githubusercontent.com/937208/79917773-1472a180-8423-11ea-9f13-e2857232611a.png)

> *Please target your PR to `master` branch.*